### PR TITLE
Fix disappearing worldmap labels bug

### DIFF
--- a/src/com/gpl/rpg/atcontentstudio/ui/map/WorldMapView.java
+++ b/src/com/gpl/rpg/atcontentstudio/ui/map/WorldMapView.java
@@ -521,16 +521,6 @@ public class WorldMapView extends JComponent implements Scrollable {
 			}
 			worldmap.getProject().getMap(id).addBacklink(worldmap);
 		}
-		
-		List<String> toRemove = new ArrayList<String>();
-		for (String s : worldmap.labels.keySet()) {
-			if (!mapLocations.containsKey(s)) {
-				toRemove.add(s);
-			}
-		}
-		for (String s : toRemove) {
-			worldmap.labels.remove(s);
-		}
 	}
 	
 }


### PR DESCRIPTION
The `worldmap.labels` map is keyed by `namedarea.id` (corresponding to `map.area`), while the `mapLocations` map is keyed by `map.id`. This causes worldmap labels to be marked for removal when there's a `namedarea.id` that does not match any `map.id`, which happens to be true for all namedareas except `crossglen `and `crossroads`.

This logic is unnecessary anyway, because `WorldMapView.pushToModel` is only invoked by `WorldmapSegment.pushToModel`, which only triggers when maps are added or moved, but not deleted. Deletions are instead handled by `WorldmapSegment.elementChanged`. As such, it should never be the case that a label is removable in a `pushToModel` call.