### PR TITLE
Ignore empty sprites in SpriteChooser

### DIFF
--- a/src/com/gpl/rpg/atcontentstudio/ui/sprites/SpriteChooser.java
+++ b/src/com/gpl/rpg/atcontentstudio/ui/sprites/SpriteChooser.java
@@ -1,24 +1,15 @@
 package com.gpl.rpg.atcontentstudio.ui.sprites;
 
-import java.awt.BorderLayout;
-import java.awt.GridBagConstraints;
-import java.awt.GridBagLayout;
-import java.awt.Image;
-import java.awt.Point;
+import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.awt.image.BufferedImage;
+import java.awt.image.WritableRaster;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-
-import javax.swing.ButtonGroup;
-import javax.swing.ImageIcon;
-import javax.swing.JDialog;
-import javax.swing.JPanel;
-import javax.swing.JScrollPane;
-import javax.swing.JToggleButton;
-import javax.swing.ScrollPaneConstants;
+import javax.swing.*;
 
 import com.gpl.rpg.atcontentstudio.ATContentStudio;
 import com.gpl.rpg.atcontentstudio.model.Project;
@@ -29,15 +20,15 @@ import com.gpl.rpg.atcontentstudio.model.sprites.Spritesheet.Category;
 public class SpriteChooser extends JDialog {
 
 	private static final long serialVersionUID = -6018113265015159521L;
-	
+
 	private static final int STD_WIDTH = 32;
 	private static final int STD_HEIGHT = 32;
 	private static final int MAX_PER_ROW = 10;
-	
-	public static Map<Project, Map<Spritesheet.Category, SpriteChooser>> cache = new LinkedHashMap<Project, Map<Spritesheet.Category,SpriteChooser>>();
-	public static Map<Project, Map<Spritesheet.Category, List<Spritesheet>>> cacheValidator = new LinkedHashMap<Project, Map<Category,List<Spritesheet>>>();
-	
-	
+
+	public static Map<Project, Map<Spritesheet.Category, SpriteChooser>> cache = new LinkedHashMap<Project, Map<Spritesheet.Category, SpriteChooser>>();
+	public static Map<Project, Map<Spritesheet.Category, List<Spritesheet>>> cacheValidator = new LinkedHashMap<Project, Map<Category, List<Spritesheet>>>();
+
+
 	public static SpriteChooser getChooser(Project proj, Spritesheet.Category category) {
 		if (cache.get(proj) == null) {
 			cache.put(proj, new LinkedHashMap<Spritesheet.Category, SpriteChooser>());
@@ -46,13 +37,13 @@ public class SpriteChooser extends JDialog {
 			cache.get(proj).put(category, new SpriteChooser(proj, category));
 		} else {
 			List<Spritesheet> spritesheets = new ArrayList<Spritesheet>();
-			for (int i=0; i<proj.getSpritesheetCount(); i++) {
+			for (int i = 0; i < proj.getSpritesheetCount(); i++) {
 				Spritesheet sheet = proj.getSpritesheet(i);
 				if (sheet.category == category) {
 					spritesheets.add(sheet);
 				}
 			}
-			if ( !spritesheets.equals(cacheValidator.get(proj).get(category)) ) {
+			if (!spritesheets.equals(cacheValidator.get(proj).get(category))) {
 				cache.get(proj).put(category, new SpriteChooser(proj, category));
 			}
 		}
@@ -65,20 +56,20 @@ public class SpriteChooser extends JDialog {
 		wanted.pack();
 		return wanted;
 	}
-	
+
 	private ButtonGroup group;
 //	private IconButton selectedOne = null;
 //	private JButton ok;
 //	private JButton cancel;
-	
+
 	public String selectedIconId = null;
-	
+
 	public SpriteChooser(Project proj, Category category) {
 		super(ATContentStudio.frame);
 		setTitle("Select a sprite");
 		setModalityType(ModalityType.APPLICATION_MODAL);
 		List<Spritesheet> spritesheets = new ArrayList<Spritesheet>();
-		for (int i=0; i<proj.getSpritesheetCount(); i++) {
+		for (int i = 0; i < proj.getSpritesheetCount(); i++) {
 			Spritesheet sheet = proj.getSpritesheet(i);
 			if (sheet.category == category) {
 				spritesheets.add(sheet);
@@ -88,8 +79,8 @@ public class SpriteChooser extends JDialog {
 			cacheValidator.put(proj, new LinkedHashMap<Spritesheet.Category, List<Spritesheet>>());
 		}
 		cacheValidator.get(proj).put(category, spritesheets);
-		
-		
+
+
 		JPanel pane = new JPanel();
 		pane.setLayout(new GridBagLayout());
 		GridBagConstraints c = new GridBagConstraints();
@@ -101,10 +92,10 @@ public class SpriteChooser extends JDialog {
 		c.gridheight = 1;
 		c.anchor = GridBagConstraints.NORTHWEST;
 		c.fill = GridBagConstraints.BOTH;
-		
+
 		List<Point> reservedSlots = new ArrayList<Point>();
 		Point nextFreeSlot = new Point(0, 0);
-		
+
 		int i;
 		Image img;
 		group = new ButtonGroup();
@@ -120,7 +111,7 @@ public class SpriteChooser extends JDialog {
 						c.gridx = 0;
 						c.gridy++;
 					}
-					nextFreeSlot.setLocation(c.gridx,  c.gridy);
+					nextFreeSlot.setLocation(c.gridx, c.gridy);
 				} else {
 					c.gridwidth = (sheet.spriteWidth / STD_WIDTH) + (sheet.spriteWidth % STD_WIDTH == 0 ? 0 : 1);
 					c.gridheight = (sheet.spriteHeight / STD_HEIGHT) + (sheet.spriteHeight % STD_HEIGHT == 0 ? 0 : 1);
@@ -157,15 +148,15 @@ public class SpriteChooser extends JDialog {
 						c.gridx = 0;
 						c.gridy++;
 					}
-					nextFreeSlot.setLocation(c.gridx,  c.gridy);
+					nextFreeSlot.setLocation(c.gridx, c.gridy);
 				}
 				i++;
 			}
 		}
-		
+
 //		ok = new JButton("Ok");
 //		cancel = new JButton("Cancel");
-		
+
 		c.gridx = 0;
 		boolean emptyLine = false;
 		while (!emptyLine) {
@@ -178,7 +169,7 @@ public class SpriteChooser extends JDialog {
 				}
 			}
 		}
-		
+
 //		JPanel buttonPane = new JPanel();
 //		buttonPane.add(cancel, BorderLayout.WEST);
 //		buttonPane.add(ok, BorderLayout.EAST);
@@ -190,7 +181,7 @@ public class SpriteChooser extends JDialog {
 		scroller.setHorizontalScrollBarPolicy(ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
 		wrapper.add(scroller, BorderLayout.CENTER);
 //		wrapper.add(buttonPane, BorderLayout.SOUTH);
-		
+
 //		ok.addActionListener(new ActionListener() {
 //			@Override
 //			public void actionPerformed(ActionEvent e) {
@@ -200,7 +191,7 @@ public class SpriteChooser extends JDialog {
 //				if (listener != null) listener.iconSelected(selectedIconId);
 //			}
 //		});
-		
+
 //		cancel.addActionListener(new ActionListener() {
 //			@Override
 //			public void actionPerformed(ActionEvent e) {
@@ -210,21 +201,21 @@ public class SpriteChooser extends JDialog {
 //				if (listener != null) listener.iconSelected(null);
 //			}
 //		});
-		
+
 		setContentPane(wrapper);
 	}
-	
+
 	private SpriteChooser.SelectionListener listener = null;
-	
+
 	public void setSelectionListener(SpriteChooser.SelectionListener l) {
 		listener = l;
 	}
-	
-	
+
+
 	public class IconButton extends JToggleButton {
-		
+
 		private static final long serialVersionUID = 7559407153561178455L;
-		
+
 		public String sheetId;
 		public int spriteIndex;
 
@@ -232,12 +223,12 @@ public class SpriteChooser extends JDialog {
 			super(new ImageIcon(img));
 			this.sheetId = sheetId;
 			this.spriteIndex = spriteIndex;
-			setToolTipText(sheetId+":"+spriteIndex);
+			setToolTipText(sheetId + ":" + spriteIndex);
 			addActionListener(new ActionListener() {
 				@Override
 				public void actionPerformed(ActionEvent e) {
 					if (IconButton.this.isSelected()) {
-						selectedIconId = IconButton.this.sheetId+":"+IconButton.this.spriteIndex;
+						selectedIconId = IconButton.this.sheetId + ":" + IconButton.this.spriteIndex;
 						SpriteChooser.this.setVisible(false);
 						SpriteChooser.this.dispose();
 						if (listener != null) listener.iconSelected(selectedIconId);
@@ -246,9 +237,9 @@ public class SpriteChooser extends JDialog {
 			});
 		}
 	}
-	
+
 	public static interface SelectionListener {
 		public void iconSelected(String selected);
 	}
-	
+
 }

--- a/src/com/gpl/rpg/atcontentstudio/ui/sprites/SpriteChooser.java
+++ b/src/com/gpl/rpg/atcontentstudio/ui/sprites/SpriteChooser.java
@@ -4,7 +4,6 @@ import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.image.BufferedImage;
-import java.awt.image.WritableRaster;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -15,6 +14,7 @@ import com.gpl.rpg.atcontentstudio.ATContentStudio;
 import com.gpl.rpg.atcontentstudio.model.Project;
 import com.gpl.rpg.atcontentstudio.model.sprites.Spritesheet;
 import com.gpl.rpg.atcontentstudio.model.sprites.Spritesheet.Category;
+import com.gpl.rpg.atcontentstudio.utils.SpriteUtils;
 
 
 public class SpriteChooser extends JDialog {
@@ -97,11 +97,14 @@ public class SpriteChooser extends JDialog {
 		Point nextFreeSlot = new Point(0, 0);
 
 		int i;
-		Image img;
+		BufferedImage img;
 		group = new ButtonGroup();
 		for (Spritesheet sheet : spritesheets) {
-			i = 0;
-			while ((img = sheet.getImage(i)) != null) {
+            i = -1;
+            while ((img = sheet.getImage(++i)) != null) {
+                if (SpriteUtils.checkIsImageEmpty(img)) {
+                    continue;
+                }
 				IconButton button = new IconButton(img, sheet.id, i);
 				group.add(button);
 				if (sheet.spriteWidth == STD_WIDTH && sheet.spriteHeight == STD_HEIGHT) {
@@ -150,7 +153,6 @@ public class SpriteChooser extends JDialog {
 					}
 					nextFreeSlot.setLocation(c.gridx, c.gridy);
 				}
-				i++;
 			}
 		}
 

--- a/src/com/gpl/rpg/atcontentstudio/utils/SpriteUtils.java
+++ b/src/com/gpl/rpg/atcontentstudio/utils/SpriteUtils.java
@@ -1,0 +1,34 @@
+package com.gpl.rpg.atcontentstudio.utils;
+
+import java.awt.image.BufferedImage;
+import java.awt.image.WritableRaster;
+
+public final class SpriteUtils {
+
+	/**
+	 * Check if the image is empty (transparent )
+	 *
+	 * @param img The image to check
+	 * @return true if the image is empty
+	 */
+	public static boolean checkIsImageEmpty(BufferedImage img) {
+		int width = img.getWidth(null);
+		int height = img.getHeight(null);
+		WritableRaster raster = img.getAlphaRaster();
+		if (raster == null) {
+			return false;
+		}
+		for (int x = 0; x < width; x++) {
+			for (int y = 0; y < height; y++) {
+				//get pixel alpha value
+				int alpha = raster.getSample(x, y, 0);
+				//if alpha is not 0 then the pixel is not transparent
+				if (alpha != 0) {
+					return false;
+				}
+			}
+		}
+		//no non-transparent pixel found
+		return true;
+	}
+}


### PR DESCRIPTION
This just ignores all the empty sprites in the chooser, to not clutter the UI.

One potential problem might be that it is now impossible to choose a transparent tile. Imo we can ignore this since it does not crash when a transparent sprite is used, we just can't select it from ATCS. If that edgecase is needed then manually editing the file to select the right sprite would be the only way to do it.