### PR TITLE
Improve workspace load speed, clean up deprecated code, exception fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ ATCS.jar
 /packaging/common/ATCS.env.bat
 /packaging/common/ATCS.env
 /packaging/common/ATCS_v*.zip
+/packaging/common/ATCS_v*.tar.gz
+.idea

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="21" project-jdk-type="JavaSDK" />
-</project>

--- a/hacked-libtiled/tiled/core/ObjectGroup.java
+++ b/hacked-libtiled/tiled/core/ObjectGroup.java
@@ -136,9 +136,7 @@ public class ObjectGroup extends MapLayer
         return clone;
     }
 
-    /**
-     * @deprecated
-     */
+    @Deprecated
     public MapLayer createDiff(MapLayer ml) {
         return null;
     }

--- a/hacked-libtiled/tiled/io/TMXMapReader.java
+++ b/hacked-libtiled/tiled/io/TMXMapReader.java
@@ -131,9 +131,9 @@ public class TMXMapReader
 
         for (int i = 0; i < parameterTypes.length; i++) {
             if ("int".equalsIgnoreCase(parameterTypes[i].getName())) {
-                conformingArguments[i] = new Integer(args[i]);
+                conformingArguments[i] = Integer.valueOf(args[i]);
             } else if ("float".equalsIgnoreCase(parameterTypes[i].getName())) {
-                conformingArguments[i] = new Float(args[i]);
+                conformingArguments[i] = Float.valueOf(args[i]);
             } else if (parameterTypes[i].getName().endsWith("String")) {
                 conformingArguments[i] = args[i];
             } else if ("boolean".equalsIgnoreCase(parameterTypes[i].getName())) {

--- a/src/com/gpl/rpg/atcontentstudio/model/Workspace.java
+++ b/src/com/gpl/rpg/atcontentstudio/model/Workspace.java
@@ -86,8 +86,18 @@ public class Workspace implements ProjectTreeNode, Serializable, JsonSerializabl
 
     @Override
     public void fromMap(Map map) {
-        if(serialVersionUID != (long) map.get("serialVersionUID")){
-            throw new SerializationException("wrong seriaVersionUID");
+        // Make this robust
+        Object serialVersion = map.get("serialVersionUID");
+        long loadedSerialVersion;
+        if (serialVersion instanceof Number) {
+            loadedSerialVersion = ((Number) serialVersion).longValue();
+        } else if (serialVersion != null) {
+            loadedSerialVersion = Long.parseLong(serialVersion.toString());
+        } else {
+            throw new SerializationException("missing serialVersionUID");
+        }
+        if (serialVersionUID != loadedSerialVersion){
+            throw new SerializationException("wrong serialVersionUID");
         }
 
         preferences.fromMap((Map) map.get("preferences"));
@@ -136,7 +146,7 @@ public class Workspace implements ProjectTreeNode, Serializable, JsonSerializabl
     }
 
     private static Workspace loadWorkspaceFromJson(File workspaceRoot, File settingsFile) {
-        Workspace w = w = new Workspace(workspaceRoot);
+        Workspace w = new Workspace(workspaceRoot);
         Map json = FileUtils.mapFromJsonFile(settingsFile);
         if (json!= null) {
             w.fromMap(json);
@@ -387,14 +397,16 @@ public class Workspace implements ProjectTreeNode, Serializable, JsonSerializabl
     }
 
     private static boolean delete(File f) {
-        boolean b = true;
         if (Files.isSymbolicLink(f.toPath())) {
-            b &= f.delete();
+            return f.delete();
         } else if (f.isDirectory()) {
-            for (File c : f.listFiles())
+            boolean b = true;
+            for (File c : Objects.requireNonNull(f.listFiles()))
                 b &= delete(c);
+            return b & f.delete();
+        } else {
+            return f.delete();
         }
-        return b & f.delete();
     }
 
     @Override

--- a/src/com/gpl/rpg/atcontentstudio/model/gamedata/ActorCondition.java
+++ b/src/com/gpl/rpg/atcontentstudio/model/gamedata/ActorCondition.java
@@ -112,6 +112,7 @@ public class ActorCondition extends JSONElement {
                 if (aCond.getDataType() == GameSource.Type.created || aCond.getDataType() == GameSource.Type.altered) {
                     aCond.writable = true;
                 }
+                aCond.parse(aCondJson);
                 category.add(aCond);
             }
         } catch (FileNotFoundException e) {

--- a/src/com/gpl/rpg/atcontentstudio/model/gamedata/Dialogue.java
+++ b/src/com/gpl/rpg/atcontentstudio/model/gamedata/Dialogue.java
@@ -322,6 +322,11 @@ public class Dialogue extends JSONElement {
                     }
                     if (reward.reward_obj != null) reward.reward_obj.addBacklink(this);
                     if (reward.map != null) reward.map.addBacklink(this);
+                    if (reward.requirements != null) {
+                        for (Requirement requirement : reward.requirements) {
+                            requirement.link();
+                        }
+                    }
                 }
             }
         }

--- a/src/com/gpl/rpg/atcontentstudio/model/gamedata/Dialogue.java
+++ b/src/com/gpl/rpg/atcontentstudio/model/gamedata/Dialogue.java
@@ -125,6 +125,8 @@ public class Dialogue extends JSONElement {
                 if (dialogue.getDataType() == GameSource.Type.created || dialogue.getDataType() == GameSource.Type.altered) {
                     dialogue.writable = true;
                 }
+                // Parse now so link() doesn't re-open and rescan the full source file per dialogue.
+                dialogue.parse(dialogueJson);
                 category.add(dialogue);
             }
         } catch (FileNotFoundException e) {

--- a/src/com/gpl/rpg/atcontentstudio/model/gamedata/Droplist.java
+++ b/src/com/gpl/rpg/atcontentstudio/model/gamedata/Droplist.java
@@ -67,6 +67,7 @@ public class Droplist extends JSONElement {
                 if (droplist.getDataType() == GameSource.Type.created || droplist.getDataType() == GameSource.Type.altered) {
                     droplist.writable = true;
                 }
+                droplist.parse(droplistJson);
                 category.add(droplist);
             }
         } catch (FileNotFoundException e) {

--- a/src/com/gpl/rpg/atcontentstudio/model/gamedata/Item.java
+++ b/src/com/gpl/rpg/atcontentstudio/model/gamedata/Item.java
@@ -97,6 +97,7 @@ public class Item extends JSONElement {
                 if (item.getDataType() == GameSource.Type.created || item.getDataType() == GameSource.Type.altered) {
                     item.writable = true;
                 }
+                item.parse(itemJson);
                 category.add(item);
             }
         } catch (FileNotFoundException e) {

--- a/src/com/gpl/rpg/atcontentstudio/model/gamedata/ItemCategory.java
+++ b/src/com/gpl/rpg/atcontentstudio/model/gamedata/ItemCategory.java
@@ -120,6 +120,7 @@ public class ItemCategory extends JSONElement {
                 if (itemCat.getDataType() == GameSource.Type.created || itemCat.getDataType() == GameSource.Type.altered) {
                     itemCat.writable = true;
                 }
+                itemCat.parse(itemCatJson);
                 category.add(itemCat);
             }
         } catch (FileNotFoundException e) {

--- a/src/com/gpl/rpg/atcontentstudio/model/gamedata/NPC.java
+++ b/src/com/gpl/rpg/atcontentstudio/model/gamedata/NPC.java
@@ -359,7 +359,7 @@ public class NPC extends JSONElement {
         }
         double experience = (((avgAttackHP * 3) + avgDefenseHP) * EXP_FACTOR_SCALING) + attackConditionBonus;
 
-        return new Double(Math.ceil(experience)).intValue();
+        return (int) Math.ceil(experience);
     }
 
 

--- a/src/com/gpl/rpg/atcontentstudio/model/gamedata/NPC.java
+++ b/src/com/gpl/rpg/atcontentstudio/model/gamedata/NPC.java
@@ -100,6 +100,7 @@ public class NPC extends JSONElement {
                 if (npc.getDataType() == GameSource.Type.created || npc.getDataType() == GameSource.Type.altered) {
                     npc.writable = true;
                 }
+                npc.parse(npcJson);
                 category.add(npc);
             }
         } catch (FileNotFoundException e) {
@@ -185,6 +186,7 @@ public class NPC extends JSONElement {
         if (deathEffect != null) {
             this.death_effect = parseDeathEffect(deathEffect);
         }
+        this.state = State.parsed;
     }
 
     @Override

--- a/src/com/gpl/rpg/atcontentstudio/model/gamedata/QuestStage.java
+++ b/src/com/gpl/rpg/atcontentstudio/model/gamedata/QuestStage.java
@@ -22,10 +22,10 @@ public class QuestStage extends JSONElement {
 
     public QuestStage clone(Quest cloneParent) {
         QuestStage clone = new QuestStage(cloneParent);
-        clone.progress = progress != null ? new Integer(progress) : null;
-        clone.log_text = log_text != null ? new String(log_text) : null;
-        clone.exp_reward = exp_reward != null ? new Integer(exp_reward) : null;
-        clone.finishes_quest = finishes_quest != null ? new Integer(finishes_quest) : null;
+        clone.progress = progress;
+        clone.log_text = log_text;
+        clone.exp_reward = exp_reward;
+        clone.finishes_quest = finishes_quest;
         clone.id = this.id;
         return clone;
     }

--- a/src/com/gpl/rpg/atcontentstudio/model/maps/MapObjectGroup.java
+++ b/src/com/gpl/rpg/atcontentstudio/model/maps/MapObjectGroup.java
@@ -21,7 +21,7 @@ public class MapObjectGroup {
         this.visible = layer.isVisible();
         this.parentMap = map;
         if (layer.getProperties().get("active") != null) {
-            active = new Boolean(((String) layer.getProperties().get("active")));
+            active = Boolean.valueOf((String) layer.getProperties().get("active"));
         } else {
             active = true;
         }

--- a/src/com/gpl/rpg/atcontentstudio/model/maps/TMXMap.java
+++ b/src/com/gpl/rpg/atcontentstudio/model/maps/TMXMap.java
@@ -66,7 +66,7 @@ public class TMXMap extends GameDataElement {
             try {
                 tmxMap = new TMXMapReader().readMap(tmxFile.getAbsolutePath(), this);
                 if (tmxMap.getProperties().get("outdoors") != null) {
-                    outside = new Integer(((String) tmxMap.getProperties().get("outdoors")));
+                    outside = Integer.valueOf((String) tmxMap.getProperties().get("outdoors"));
                 }
                 if (tmxMap.getProperties().get("colorfilter") != null) {
                     colorFilter = ColorFilter.valueOf(((String) tmxMap.getProperties().get("colorfilter")));
@@ -104,7 +104,7 @@ public class TMXMap extends GameDataElement {
             clone.usedSpritesheets = new HashSet<Spritesheet>();
             clone.tmxMap = new TMXMapReader().readMap(new StringReader(this.toXml()), clone);
             if (clone.tmxMap.getProperties().get("outdoors") != null) {
-                clone.outside = new Integer(((String) clone.tmxMap.getProperties().get("outdoors")));
+                clone.outside = Integer.valueOf((String) clone.tmxMap.getProperties().get("outdoors"));
             }
             if (clone.tmxMap.getProperties().get("colorfilter") != null) {
                 clone.colorFilter = ColorFilter.valueOf(((String) tmxMap.getProperties().get("colorfilter")));

--- a/src/com/gpl/rpg/atcontentstudio/model/maps/TMXMapSet.java
+++ b/src/com/gpl/rpg/atcontentstudio/model/maps/TMXMapSet.java
@@ -18,6 +18,8 @@ import java.nio.file.*;
 import java.util.List;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class TMXMapSet implements ProjectTreeNode {
 
@@ -29,6 +31,7 @@ public class TMXMapSet implements ProjectTreeNode {
     public static final String DEBUG_SUFFIX = "_debug";
     public static final String RESOURCE_PREFIX = "@xml/";
     public static final String FILENAME_SUFFIX = ".tmx";
+    public static final String FILENAME_REGEX = "^(.+)\\.tmx$";
 
     public File mapFolder = null;
     public List<TMXMap> tmxMaps;
@@ -39,7 +42,7 @@ public class TMXMapSet implements ProjectTreeNode {
         this.parent = source;
         if (source.type == GameSource.Type.source) {
             this.mapFolder = new File(source.baseFolder, DEFAULT_REL_PATH_IN_SOURCE);
-        } else if (source.type == GameSource.Type.created | source.type == GameSource.Type.altered) {
+        } else if (source.type == GameSource.Type.created || source.type == GameSource.Type.altered) {
             this.mapFolder = new File(source.baseFolder, DEFAULT_REL_PATH_IN_PROJECT);
             if (!this.mapFolder.exists()) {
                 this.mapFolder.mkdirs();
@@ -84,37 +87,39 @@ public class TMXMapSet implements ProjectTreeNode {
             final Path folderPath = Paths.get(mapFolder.getAbsolutePath());
             Thread watcher = new Thread("Map folder watcher for " + getProject().name + "/" + source.type) {
                 public void run() {
-                    WatchService watchService;
-
-                    while (getProject().open) {
-                        try {
-                            watchService = FileSystems.getDefault().newWatchService();
-                            /*WatchKey watchKey = */
-                            folderPath.register(watchService, StandardWatchEventKinds.ENTRY_MODIFY, StandardWatchEventKinds.ENTRY_CREATE);
-                            WatchKey wk;
-                            validService:
-                            while (getProject().open) {
-                                wk = watchService.poll(10, TimeUnit.SECONDS);
-                                if (wk != null) {
-                                    for (WatchEvent<?> event : wk.pollEvents()) {
-                                        Path changed = (Path) event.context();
-                                        String name = changed.getFileName().toString();
-                                        String id = name.substring(0, name.length() - 4);
-                                        TMXMap map = getMap(id);
-                                        if (map != null) {
-                                            map.mapChangedOnDisk();
-                                        }
-                                    }
-                                    if (!wk.reset()) {
-                                        watchService.close();
-                                        break validService;
+                    WatchService watchService = null;
+                    Pattern tmxFilenamePattern = Pattern.compile(FILENAME_REGEX, Pattern.CASE_INSENSITIVE);
+                    try {
+                        watchService = FileSystems.getDefault().newWatchService();
+                        folderPath.register(watchService, StandardWatchEventKinds.ENTRY_MODIFY, StandardWatchEventKinds.ENTRY_CREATE);
+                        while (getProject().open) {
+                            WatchKey wk = watchService.poll(10, TimeUnit.SECONDS);
+                            if (wk != null) {
+                                for (WatchEvent<?> event : wk.pollEvents()) {
+                                    Path changed = (Path) event.context();
+                                    String name = changed.getFileName().toString();
+                                    Matcher matcher = tmxFilenamePattern.matcher(name); // use regex to make sure we only match .tmx files, and also avoid out-of-bounds for too-short filenames
+                                    if (!matcher.matches()) continue;
+                                    String id = matcher.group(1);
+                                    TMXMap map = getMap(id);
+                                    if (map != null) {
+                                        map.mapChangedOnDisk();
                                     }
                                 }
+                                if (!wk.reset()) {
+                                    break;
+                                }
                             }
-                        } catch (IOException e) {
-                            e.printStackTrace();
-                        } catch (InterruptedException e) {
-                            e.printStackTrace();
+                        }
+                    } catch (IOException | InterruptedException e) {
+                        e.printStackTrace();
+                    } finally {
+                        if (watchService != null) {
+                            try {
+                                watchService.close();
+                            } catch (IOException e) {
+                                e.printStackTrace();
+                            }
                         }
                     }
                 }

--- a/src/com/gpl/rpg/atcontentstudio/model/sprites/Spritesheet.java
+++ b/src/com/gpl/rpg/atcontentstudio/model/sprites/Spritesheet.java
@@ -165,12 +165,12 @@ public class Spritesheet extends GameDataElement {
         sx1 = (index * spriteWidth) % spritesheet.getWidth();
         sy1 = spriteHeight * ((index * spriteWidth) / spritesheet.getWidth());
         if (sx1 + spriteWidth > spritesheet.getWidth() || sy1 + spriteHeight > spritesheet.getHeight()) {
-            g.finalize();
+            g.dispose();
             return null;
         }
         g.drawImage(spritesheet, 0, 0, spriteWidth, spriteHeight, sx1, sy1, sx1 + spriteWidth, sy1 + spriteHeight, null);
         result.flush();
-        g.finalize();
+        g.dispose();
         cache_full_size.put(index, result);
         return result;
     }

--- a/src/com/gpl/rpg/atcontentstudio/ui/gamedataeditors/DialogueEditor.java
+++ b/src/com/gpl/rpg/atcontentstudio/ui/gamedataeditors/DialogueEditor.java
@@ -1378,7 +1378,7 @@ public class DialogueEditor extends JSONElementEditor {
                 if (selectedRewardRequirement.type == Requirement.RequirementType.skillLevel || selectedRewardRequirement.type == Requirement.RequirementType.skillIncrease) {
                     selectedRewardRequirement.required_obj_id = value == null ? null : value.toString();
                 }
-                requirementsListModel.itemChanged(selectedRewardRequirement);
+                rewardRequirementsListModel.itemChanged(selectedRewardRequirement);
             } else if (source == rewardRequirementObjId) {
                 selectedRewardRequirement.required_obj_id = (String) value;
                 selectedRewardRequirement.required_obj = null;

--- a/src/com/gpl/rpg/atcontentstudio/ui/map/TMXMapEditor.java
+++ b/src/com/gpl/rpg/atcontentstudio/ui/map/TMXMapEditor.java
@@ -1372,6 +1372,11 @@ public class TMXMapEditor extends Editor implements TMXMap.MapChangedOnDiskListe
             final Graphics2D g2d = (Graphics2D) g.create();
             final Rectangle clip = g2d.getClipBounds();
 
+            // Bail out if we get called on a null map (usually a synchronization issue)
+            if (map == null || map.tmxMap == null) {
+                g2d.dispose();
+                return;
+            }
 
             // Draw a gray background
             g2d.setPaint(new Color(100, 100, 100));
@@ -1577,11 +1582,7 @@ public class TMXMapEditor extends Editor implements TMXMap.MapChangedOnDiskListe
                         if (confirm == JOptionPane.CANCEL_OPTION) return;
                     }
                     reload.setEnabled(false);
-                    (new Thread() {
-                        public void run() {
-                            map.reload();
-                        }
-                    }).start();
+                    map.reload(); // This is fast enough to be synchronous, and that avoids async issues with paintComponent()
                 }
             });
             if (map.getDataType() == GameSource.Type.altered) {
@@ -2234,6 +2235,10 @@ public class TMXMapEditor extends Editor implements TMXMap.MapChangedOnDiskListe
         public void paintComponent(Graphics g) {
             final Graphics2D g2d = (Graphics2D) g.create();
             final Rectangle clip = g2d.getClipBounds();
+            if (map == null || map.tmxMap == null) {
+                g2d.dispose();
+                return;
+            }
 
             // Draw a gray background
             g2d.setPaint(new Color(100, 100, 100));

--- a/src/net/launchpad/tobal/poparser/POParser.java
+++ b/src/net/launchpad/tobal/poparser/POParser.java
@@ -26,7 +26,6 @@ public class POParser
     /**
      * Creates a POParser object. Use getPOFile() method,
      * to access parsed data.
-     * @param file, File object of the PO file
      */
     public POParser()
     {
@@ -120,7 +119,7 @@ public class POParser
 
         // is this header?
         Vector<String> rawentry = vectors.get(0);
-        if(new Integer(rawentry.get(0)) == 0 && rawentry.contains("msgid \"\""))
+        if(Integer.parseInt(rawentry.get(0)) == 0 && rawentry.contains("msgid \"\""))
         {
             for(int i = 1; i < rawentry.size(); i++)
             {
@@ -142,7 +141,7 @@ public class POParser
 
         // is this header
         Vector<String> rawentry = vectors.get(0);
-        if(new Integer(rawentry.get(0)) == 0 && rawentry.contains("msgid \"\""))
+        if(Integer.parseInt(rawentry.get(0)) == 0 && rawentry.contains("msgid \"\""))
         {
             thereIsHeader = true;
         }

--- a/src/prefuse/data/FilteredSpanningTree.java
+++ b/src/prefuse/data/FilteredSpanningTree.java
@@ -15,8 +15,8 @@ public class FilteredSpanningTree extends Tree {
     /** Edge table schema used by the spanning tree. */
     protected static final Schema EDGE_SCHEMA = new Schema();
     static {
-        EDGE_SCHEMA.addColumn(DEFAULT_SOURCE_KEY, int.class, new Integer(-1));
-        EDGE_SCHEMA.addColumn(DEFAULT_TARGET_KEY, int.class, new Integer(-1));
+        EDGE_SCHEMA.addColumn(DEFAULT_SOURCE_KEY, int.class, -1);
+        EDGE_SCHEMA.addColumn(DEFAULT_TARGET_KEY, int.class, -1);
         EDGE_SCHEMA.addColumn(SOURCE_EDGE, int.class);
     }
     


### PR DESCRIPTION
Several improvements and fixes - most significantly, a 6x workspace load speedup (from 24 seconds to under four on my system).  This is accomplished by forcing json files to be parsed when they are first loaded, instead of deferring them (lazy parsing).  This prevents the link() routine from causing thousands of extra file ops during workspace load (primarily conversations).

Other fixes:
* Add linking for new reward requirements (still need to check on special quest backlinks?)
* Fix bad references in new reward requirements code
* Clean up deprecated constructors and method calls - now compiles without warnings under JDK 21
* Use valueOf() or parseInt() instead of deprecated Integer, Boolean, and Float constructors.
* Replace Graphics.finalize() with dispose().
* Update @deprecated annotation and remove redundant String/Integer allocations in clone methods.
* Fix bug in project delete code (symlinks causing error)
* Fix memory leak in folder watcher (caused "out of file descriptor" exceptions on project delete)
* fix buffer underflow in map change detection
* Make map serialization check robust
* make reload() button single threaded (avoids race with paintComponent and resulting exceptions)
* add null guard in paintComponent() (2x)
* add .idea to gitignore to keep editor state out of git
* remove .idea/misc.xml from git (JDK spec too variable between systems)
* Typo and minor logic fixes