### PR TITLE
Restore Java 17 compatability

### DIFF
--- a/packaging/package.sh
+++ b/packaging/package.sh
@@ -72,7 +72,7 @@ echo 'Building java classes'
 
 # shellcheck disable=SC2086
 # (we need word splitting here to pass multiple files)
-javac -cp "${TEMP_DIR}" -d "${TEMP_DIR}" ${SOURCE_FILES}
+javac --release 17 -cp "${TEMP_DIR}" -d "${TEMP_DIR}" ${SOURCE_FILES}
 if [ $? -ne 0 ]; then
     echo "Compilation failed. Please check errors above."
     exit 1

--- a/src/com/gpl/rpg/atcontentstudio/ui/WorkspaceActions.java
+++ b/src/com/gpl/rpg/atcontentstudio/ui/WorkspaceActions.java
@@ -30,10 +30,6 @@ public class WorkspaceActions {
     ProjectTreeNode selectedNode = null;
     TreePath[] selectedPaths = null;
 
-    /**
-     * Get a sensible workspace parent location: either the parent of the current workspace, or the home directory (check if this works on windows)
-     * @return the directory to start the chooser at
-     */
     private File getWorkspaceChooserDirectory() {
         if (Workspace.activeWorkspace != null && Workspace.activeWorkspace.baseFolder != null) {
             File parent = Workspace.activeWorkspace.baseFolder.getParentFile();
@@ -44,11 +40,6 @@ public class WorkspaceActions {
         return home != null ? new File(home) : new File(".");
     }
 
-    /**
-     * Launch a new workspace process
-     * @param workspaceRoot the root of the workspace
-     * @param dialogTitle the title to use for an error message dialog if there is an error
-     */
     public void launchWorkspace(File workspaceRoot, String dialogTitle) {
         if (workspaceRoot == null) return;
 
@@ -64,9 +55,6 @@ public class WorkspaceActions {
         }
     }
 
-    /**
-     * Restart the current workspace.  Saves the UI state, starts the restart helper process, and shuts this one down.
-     */
     private void restartCurrentWorkspace() {
         try {
             persistUiStateIfPossible();
@@ -82,17 +70,10 @@ public class WorkspaceActions {
         }
     }
 
-    /**
-     * Determine if there's an active workspace, or if we haven't opened one yet.
-     * @return true if there's an active workspace
-     */
     private boolean hasActiveWorkspace() {
         return Workspace.activeWorkspace != null && Workspace.activeWorkspace.baseFolder != null;
     }
 
-    /**
-     * Create a new workspace
-     */
     public ATCSAction newWorkspace = new ATCSAction("New Workspace...", "Creates a new workspace and opens it") {
         public void actionPerformed(ActionEvent e) {
             JFileChooser chooser = new JFileChooser(getWorkspaceChooserDirectory());
@@ -230,7 +211,8 @@ public class WorkspaceActions {
 
     public ATCSAction saveElement = new ATCSAction("Save this element", "Saves the current state of this element on disk") {
         public void actionPerformed(ActionEvent e) {
-            if (!(selectedNode instanceof GameDataElement node)) return;
+            if (!(selectedNode instanceof GameDataElement)) return;
+            final GameDataElement node = ((GameDataElement) selectedNode);
             if (node.needsSaving()) {
                 node.save();
                 ATContentStudio.frame.nodeChanged(node);
@@ -256,7 +238,6 @@ public class WorkspaceActions {
         }
 
         public void actionPerformed(ActionEvent e) {
-            // TODO: Overhaul this - check thread safety on BOTH branches (UI stuff should be on EDT only)
             if (multiMode) {
                 if (elementsToDelete == null) return;
 
@@ -273,7 +254,9 @@ public class WorkspaceActions {
                             @SuppressWarnings("unchecked")
                             GameDataCategory<JSONElement> category = (GameDataCategory<JSONElement>) element.getParent();
                             category.remove((JSONElement) element);
-                            impactedCategories.computeIfAbsent(category, k -> new HashSet<File>());
+                            if (impactedCategories.get(category) == null) {
+                                impactedCategories.put(category, new HashSet<File>());
+                            }
 
                             GameDataElement newOne = element.getProject().getGameDataElement(((JSONElement) element).getClass(), element.id);
                             if (element instanceof Quest) {
@@ -329,7 +312,8 @@ public class WorkspaceActions {
                     }
                 }.start();
             } else {
-                if (selectedNode == null || !(selectedNode instanceof GameDataElement node)) return;
+                if (selectedNode == null || !(selectedNode instanceof GameDataElement)) return;
+                final GameDataElement node = ((GameDataElement) selectedNode);
 
                 if (!ConfirmationDialogs.confirmDelete(node)) return;
 
@@ -342,51 +326,45 @@ public class WorkspaceActions {
                     @Override
                     public void run() {
                         node.childrenRemoved(new ArrayList<ProjectTreeNode>());
-                        switch (node) {
-                            case JSONElement jsonElement -> {
-                                if (node.getParent() instanceof GameDataCategory<?>) {
-                                    ((GameDataCategory<?>) node.getParent()).removeGeneric(jsonElement);
-                                    List<SaveEvent> events = node.attemptSave();
-                                    if (events == null || events.isEmpty()) {
-                                        node.save();
-                                    } else {
-                                        SwingUtilities.invokeLater(() -> new SaveItemsWizard(events, null).setVisible(true));
-                                    }
-                                    GameDataElement newOne = node.getProject().getGameDataElement(jsonElement.getClass(), node.id);
-                                    if (node instanceof Quest) {
-                                        for (QuestStage oldStage : ((Quest) node).stages) {
-                                            QuestStage newStage = newOne != null ? ((Quest) newOne).getStage(oldStage.progress) : null;
-                                            for (GameDataElement backlink : oldStage.getBacklinks()) {
-                                                backlink.elementChanged(oldStage, newStage);
-                                            }
+                        // Don't change to pattern-based switch as long as we need Java 17 support
+                        if (node instanceof JSONElement) {
+                            if (node.getParent() instanceof GameDataCategory<?>) {
+                                ((GameDataCategory<?>) node.getParent()).removeGeneric((JSONElement) node);
+                                List<SaveEvent> events = node.attemptSave();
+                                if (events == null || events.isEmpty()) {
+                                    node.save();
+                                } else {
+                                    SwingUtilities.invokeLater(() -> new SaveItemsWizard(events, null).setVisible(true));
+                                }
+                                GameDataElement newOne = node.getProject().getGameDataElement(((JSONElement) node).getClass(), node.id);
+                                if (node instanceof Quest) {
+                                    for (QuestStage oldStage : ((Quest) node).stages) {
+                                        QuestStage newStage = newOne != null ? ((Quest) newOne).getStage(oldStage.progress) : null;
+                                        for (GameDataElement backlink : oldStage.getBacklinks()) {
+                                            backlink.elementChanged(oldStage, newStage);
                                         }
                                     }
-                                    for (GameDataElement backlink : node.getBacklinks()) {
-                                        backlink.elementChanged(node, newOne);
-                                    }
                                 }
-                            }
-                            case TMXMap tmxMap -> {
-                                tmxMap.delete();
-                                GameDataElement newOne = node.getProject().getMap(node.id);
                                 for (GameDataElement backlink : node.getBacklinks()) {
                                     backlink.elementChanged(node, newOne);
                                 }
                             }
-                            case WriterModeData writerModeData -> {
-                                WriterModeDataSet parent = (WriterModeDataSet) node.getParent();
-                                parent.writerModeDataList.remove(node);
+                        } else if (node instanceof TMXMap) {
+                            ((TMXMap) node).delete();
+                            GameDataElement newOne = node.getProject().getMap(node.id);
+                            for (GameDataElement backlink : node.getBacklinks()) {
+                                backlink.elementChanged(node, newOne);
                             }
-                            case WorldmapSegment worldmapSegment -> {
-                                if (node.getParent() instanceof Worldmap) {
-                                    ((Worldmap) node.getParent()).remove(node);
-                                    node.save();
-                                    for (GameDataElement backlink : node.getBacklinks()) {
-                                        backlink.elementChanged(node, node.getProject().getWorldmapSegment(node.id));
-                                    }
+                        } else if (node instanceof WriterModeData) {
+                            WriterModeDataSet parent = (WriterModeDataSet) node.getParent();
+                            parent.writerModeDataList.remove(node);
+                        } else if (node instanceof WorldmapSegment) {
+                            if (node.getParent() instanceof Worldmap) {
+                                ((Worldmap) node.getParent()).remove(node);
+                                node.save();
+                                for (GameDataElement backlink : node.getBacklinks()) {
+                                    backlink.elementChanged(node, node.getProject().getWorldmapSegment(node.id));
                                 }
-                            }
-                            default -> {
                             }
                         }
                     }
@@ -581,7 +559,7 @@ public class WorkspaceActions {
         }
 
         public void selectionChanged(ProjectTreeNode selectedNode, TreePath[] selectedPaths) {
-            setEnabled(selectedNode instanceof Dialogue);
+            setEnabled(selectedNode != null && selectedNode instanceof Dialogue);
         }
     };
 
@@ -596,6 +574,9 @@ public class WorkspaceActions {
 
     };
 
+    List<ATCSAction> selectionAwareActions = new ArrayList<WorkspaceActions.ATCSAction>();
+
+
     private void persistUiStateIfPossible() {
         if (ATContentStudio.frame != null) {
             ATContentStudio.frame.persistWorkspaceUiState();
@@ -603,8 +584,6 @@ public class WorkspaceActions {
             Workspace.saveActive();
         }
     }
-
-    final List<ATCSAction> selectionAwareActions = new ArrayList<WorkspaceActions.ATCSAction>();
 
     public WorkspaceActions() {
         selectionAwareActions.add(closeProject);
@@ -620,6 +599,7 @@ public class WorkspaceActions {
         selectionAwareActions.add(compareNPCs);
         selectionAwareActions.add(exportProject);
         selectionAwareActions.add(createWriter);
+//		selectionAwareActions.add(testCommitWriter);
         selectionAwareActions.add(generateWriter);
         selectionChanged(null, null);
     }
@@ -662,7 +642,6 @@ public class WorkspaceActions {
             return values.get(key);
         }
 
-        private final List<PropertyChangeListener> listeners = new CopyOnWriteArrayList<PropertyChangeListener>();
         @Override
         public void putValue(String key, Object value) {
             PropertyChangeEvent event = new PropertyChangeEvent(this, key, values.get(key), value);
@@ -685,6 +664,8 @@ public class WorkspaceActions {
         public boolean isEnabled() {
             return enabled;
         }
+
+        private List<PropertyChangeListener> listeners = new CopyOnWriteArrayList<PropertyChangeListener>();
 
         @Override
         public void addPropertyChangeListener(PropertyChangeListener listener) {


### PR DESCRIPTION
Patch to revert a change that broke Java 17 compatibility and also force the build script to compile with java 17 support (or cause an error at build time).

Note that I'd prefer we _don't_ merge this, and instead resolve the issue in other ways (i.e., provide an installer with a packaged jvm, or get users to update their system jvm), but I want to make this available in case we need a short-term fix.

Also note that this patch converts the line endings on `ui/WorkspaceActions.java` from CRLF to LF, so it's hard to see the lines that changed in github below.  Not sure why this didn't happen on the earlier changes - it should have, given our `.gitattributes` config - but you can view the diff using [this](https://github.com/AndorsTrailRelease/ATCS/compare/master...gmn42:ATCS:java-17-compat?diff=split&w=1) link.  Hopefully we can renormalize the entire repo and avoid this on future commits.