### PR TITLE
Add nextPhraseID conversation reward type.

### DIFF
--- a/src/com/gpl/rpg/atcontentstudio/model/gamedata/Dialogue.java
+++ b/src/com/gpl/rpg/atcontentstudio/model/gamedata/Dialogue.java
@@ -74,7 +74,8 @@ public class Dialogue extends JSONElement {
             deactivateMapObjectGroup,
             changeMapFilter,
             mapchange,
-            changeIcon
+            changeIcon,
+            setNextPhraseID,
         }
 
         public List<Requirement> requirements = null;

--- a/src/com/gpl/rpg/atcontentstudio/ui/gamedataeditors/DialogueEditor.java
+++ b/src/com/gpl/rpg/atcontentstudio/ui/gamedataeditors/DialogueEditor.java
@@ -421,6 +421,20 @@ public class DialogueEditor extends JSONElementEditor {
                     rewardObj = null;
                     rewardValue = addIntegerField(pane, "Icon number: ", reward.reward_value, false, writable, listener);
                     break;
+                case setNextPhraseID:
+                    // choose initial Dialogue for the dialogue combo from reward.reward_obj or reward.reward_obj_id
+                    Dialogue initialNextPhrase = null;
+                    if (reward.reward_obj instanceof Dialogue) {
+                        initialNextPhrase = (Dialogue) reward.reward_obj;
+                    } else if (reward.reward_obj_id != null) {
+                        initialNextPhrase = ((Dialogue) target).getProject().getDialogue(reward.reward_obj_id);
+                    }
+                    rewardMap = null;
+                    rewardObjId = null;
+                    rewardObjIdCombo = addDialogueBox(pane, ((Dialogue) target).getProject(), "Next phrase: ", initialNextPhrase, writable, listener);
+                    rewardObj = null;
+                    rewardValue = null;
+                    break;
 
             }
         }
@@ -1045,6 +1059,10 @@ public class DialogueEditor extends JSONElementEditor {
                     label.setText("Change Icon to " + reward.reward_value + " " + rewardObjDesc);
                     if (reward.reward_obj != null) label.setIcon(new ImageIcon(DefaultIcons.getNPCIcon()));
                     break;
+                case setNextPhraseID:
+                    label.setText("Set next phrase ID to " + rewardObjDesc);
+                    label.setIcon(new ImageIcon(DefaultIcons.getDialogueIcon()));
+                    break;
             }
         } else {
             label.setText("New, undefined reward");
@@ -1240,7 +1258,32 @@ public class DialogueEditor extends JSONElementEditor {
                 selectedReward.reward_obj_id = rewardObjId.getText();
                 rewardsListModel.itemChanged(selectedReward);
             } else if (source == rewardObjIdCombo) {
-                selectedReward.reward_obj_id = rewardObjIdCombo.getSelectedItem().toString();
+                Object sel = rewardObjIdCombo.getSelectedItem();
+
+                // Remove backlink from previous reward_obj if any
+                if (selectedReward.reward_obj != null) {
+                    selectedReward.reward_obj.removeBacklink(dialogue);
+                }
+                selectedReward.reward_obj = null;
+                selectedReward.reward_obj_id = null;
+
+                if (sel == null) {
+                    // nothing else to do - both fields cleared
+                } else if (sel instanceof GameDataElement) {
+                    // If the combo contains a GameDataElement (Dialogue, Item, Quest, etc.)
+                    selectedReward.reward_obj = (GameDataElement) sel;
+                    selectedReward.reward_obj_id = selectedReward.reward_obj.id;
+                    selectedReward.reward_obj.addBacklink(dialogue);
+                } else if (sel instanceof Enum) {
+                    // Enum selections (e.g. TMXMap.ColorFilter)
+                    selectedReward.reward_obj_id = ((Enum<?>) sel).name();
+                } else if (sel instanceof String) {
+                    // Plain string selection
+                    selectedReward.reward_obj_id = (String) sel;
+                } else {
+                    // Fallback: store string representation
+                    selectedReward.reward_obj_id = sel.toString();
+                }
                 rewardsListModel.itemChanged(selectedReward);
             } else if (source == rewardObj) {
                 if (selectedReward.reward_obj != null) {


### PR DESCRIPTION
This pull request adds a new reward type, `setNextPhraseID`, to the dialogue system and updates the editor to support selecting and displaying the next dialogue phrase as a reward. The main changes include extending the `RewardType` enum, updating the UI to allow selection of the next phrase, and ensuring proper handling and display of this new reward type.  This also fixes handling of backlinks in the combo boxes for other types of data.

**Dialogue reward system enhancements:**

* Added `setNextPhraseID` to the `RewardType` enum in `Dialogue.java` to support linking to another dialogue phrase as a reward.
* Updated the UI in `DialogueEditor.java` to allow users to select the next dialogue phrase when `setNextPhraseID` is chosen, including initializing the selection and updating the reward object and ID appropriately. [[1]](diffhunk://#diff-f9b69b6f3172737b4d257f333a57364c927e2091be3b173e471d9ba1de46e346R424-R437) [[2]](diffhunk://#diff-f9b69b6f3172737b4d257f333a57364c927e2091be3b173e471d9ba1de46e346L1243-R1286)
* Enhanced the reward label rendering to display "Set next phrase ID to ..." and show a dialogue icon when the new reward type is used.