### PR TITLE
Worldmap zoom fixes

### DIFF
--- a/src/com/gpl/rpg/atcontentstudio/ui/map/MapColorFilters.java
+++ b/src/com/gpl/rpg/atcontentstudio/ui/map/MapColorFilters.java
@@ -15,7 +15,8 @@ public class MapColorFilters {
      * custom pixel operation.
      *
      * @param colorFilter the filter to convert
-     * @return the color matrix, or {@code null} if the filter is not supported
+     * @return the color matrix, identity for {@link TMXMap.ColorFilter#none}, or
+     * {@code null} if the filter is not supported
      */
     public static float[] buildMatrixForFilter(com.gpl.rpg.atcontentstudio.model.maps.TMXMap.ColorFilter colorFilter) {
         float[] m;
@@ -112,11 +113,15 @@ public class MapColorFilters {
      * This reuses the same matrix definitions as the live-graphics path, but it
      * mutates the {@link BufferedImage} pixels directly so callers can safely use it
      * when the on-screen rendering pipeline does not support custom composites.
+     * A {@code null} or {@link TMXMap.ColorFilter#none} filter is treated as a no-op.
      *
      * @param colorFilter the filter to apply
      * @param image the image to modify in place
      */
     public static void applyColorFilter(TMXMap.ColorFilter colorFilter, BufferedImage image) {
+        if (colorFilter == null || colorFilter == TMXMap.ColorFilter.none) {
+            return;
+        }
         float[] matrix = buildMatrixForFilter(colorFilter);
         if (matrix != null) {
             applyMatrixToImage(matrix, image);

--- a/src/com/gpl/rpg/atcontentstudio/ui/map/WorldMapEditor.java
+++ b/src/com/gpl/rpg/atcontentstudio/ui/map/WorldMapEditor.java
@@ -21,6 +21,9 @@ import javax.swing.*;
 import javax.swing.event.*;
 import java.awt.*;
 import java.awt.event.*;
+import javax.swing.plaf.basic.BasicSliderUI;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -113,8 +116,6 @@ public class WorldMapEditor extends Editor implements FieldUpdateListener {
         pane.setLayout(new JideBoxLayout(pane, JideBoxLayout.PAGE_AXIS));
 
         addLabelField(pane, "Worldmap File: ", ((Worldmap) worldmap.getParent()).worldmapFile.getAbsolutePath());
-        pane.add(createButtonPane(worldmap), JideBoxLayout.FIX);
-
         mapView = new WorldMapView(worldmap);
         JScrollPane mapScroller = new JScrollPane(mapView);
         final JViewport vPort = mapScroller.getViewport();
@@ -122,11 +123,31 @@ public class WorldMapEditor extends Editor implements FieldUpdateListener {
         final JSlider zoomSlider = new JSlider(WorldMapView.MIN_ZOOM, WorldMapView.MAX_ZOOM, (int) (mapView.zoomLevel / WorldMapView.ZOOM_RATIO));
         zoomSlider.setSnapToTicks(true);
         zoomSlider.setMinorTickSpacing(WorldMapView.INC_ZOOM);
-        zoomSlider.setOrientation(JSlider.VERTICAL);
+        zoomSlider.setPaintTicks(false);
+        zoomSlider.setPaintLabels(false);
+        zoomSlider.setLabelTable(null);
+        // Override the UI because GTK+ prints the position and takes a lot of space
+        zoomSlider.setUI(new BasicSliderUI(zoomSlider) {
+            @Override
+            public void paintTicks(Graphics g) {
+            }
+
+            @Override
+            public void paintLabels(Graphics g) {
+            }
+        });
+        zoomSlider.setOrientation(JSlider.HORIZONTAL);
+        final JLabel zoomValueLabel = new JLabel(String.format(java.util.Locale.ROOT, "%.2fx", mapView.zoomLevel));
         JPanel zoomSliderPane = new JPanel();
-        zoomSliderPane.setLayout(new JideBoxLayout(zoomSliderPane, JideBoxLayout.PAGE_AXIS));
+        zoomSliderPane.setLayout(new JideBoxLayout(zoomSliderPane, JideBoxLayout.LINE_AXIS, 6));
         zoomSliderPane.add(zoomSlider, JideBoxLayout.VARY);
+        zoomSliderPane.add(zoomValueLabel, JideBoxLayout.FIX);
         zoomSliderPane.add(new JLabel(new ImageIcon(DefaultIcons.getZoomIcon())), JideBoxLayout.FIX);
+
+        JPanel headerPane = new JPanel(new BorderLayout(6, 0));
+        headerPane.add(createButtonPane(worldmap), BorderLayout.CENTER);
+        headerPane.add(zoomSliderPane, BorderLayout.EAST);
+        pane.add(headerPane, JideBoxLayout.FIX);
 
 
         if (target.writable) {
@@ -237,7 +258,6 @@ public class WorldMapEditor extends Editor implements FieldUpdateListener {
 
         JPanel mapZoomPane = new JPanel();
         mapZoomPane.setLayout(new BorderLayout());
-        mapZoomPane.add(zoomSliderPane, BorderLayout.WEST);
         mapZoomPane.add(mapScroller, BorderLayout.CENTER);
 
         JPanel mapPropsPane = new JPanel();
@@ -245,36 +265,82 @@ public class WorldMapEditor extends Editor implements FieldUpdateListener {
 
         setCurrentSelectionModel(msmListModel, msmListSelectionModel);
 
+        final ChangeListener zoomChangeListener = e -> {
+            Rectangle view = vPort.getViewRect();
+
+            float oldZoomLevel = mapView.zoomLevel;
+            mapView.zoomLevel = zoomSlider.getValue() * WorldMapView.ZOOM_RATIO;
+            zoomValueLabel.setText(String.format(java.util.Locale.ROOT, "%.2fx", mapView.zoomLevel));
+
+            int newCenterX = (int) (view.getCenterX() / oldZoomLevel * mapView.zoomLevel);
+            int newCenterY = (int) (view.getCenterY() / oldZoomLevel * mapView.zoomLevel);
+
+            view.x = newCenterX - (view.width / 2);
+            view.y = newCenterY - (view.height / 2);
+
+            mapView.scrollRectToVisible(view);
+            mapView.revalidate();
+            mapView.repaint();
+        };
+
+        zoomSlider.addChangeListener(zoomChangeListener);
+        mapScroller.setWheelScrollingEnabled(false);
+        mapView.addMouseWheelListener(e -> {
+            Point mouse = e.getPoint();
+            Rectangle view = vPort.getViewRect();
+            int anchorX = view.x + mouse.x;
+            int anchorY = view.y + mouse.y;
+
+            int newZoom = zoomSlider.getValue() - (e.getWheelRotation() * WorldMapView.INC_ZOOM);
+            newZoom = Math.max(zoomSlider.getMinimum(), Math.min(WorldMapView.MAX_ZOOM, newZoom));
+            if (newZoom != zoomSlider.getValue()) {
+                float oldZoomLevel = mapView.zoomLevel;
+                float nextZoomLevel = newZoom * WorldMapView.ZOOM_RATIO;
+                int newViewX = Math.round(anchorX * nextZoomLevel / oldZoomLevel - mouse.x);
+                int newViewY = Math.round(anchorY * nextZoomLevel / oldZoomLevel - mouse.y);
+                zoomSlider.setValue(newZoom);
+                view.setLocation(newViewX, newViewY);
+                mapView.scrollRectToVisible(view);
+            }
+            e.consume();
+        });
 
         final JSplitPane mapAndPropsSplitter = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, mapZoomPane, mapPropsPane);
-        SwingUtilities.invokeLater(new Runnable() {
+        SwingUtilities.invokeLater(() -> mapAndPropsSplitter.setDividerLocation(0.8d));
+
+        // Add listener to fit the map to the viewport when the divider is in its final initial location
+        mapAndPropsSplitter.addPropertyChangeListener(JSplitPane.DIVIDER_LOCATION_PROPERTY, new PropertyChangeListener() {
+            private boolean fitted = false;
+            private int lastDividerLocation = Integer.MIN_VALUE;
+
             @Override
-            public void run() {
-                mapAndPropsSplitter.setDividerLocation(0.8d);
+            public void propertyChange(PropertyChangeEvent evt) {
+                if (fitted) {
+                    return;
+                }
+
+                lastDividerLocation = mapAndPropsSplitter.getDividerLocation();
+                SwingUtilities.invokeLater(() -> SwingUtilities.invokeLater(() -> {
+                    if (fitted || mapAndPropsSplitter.getDividerLocation() != lastDividerLocation) {
+                        return;
+                    }
+
+                    Dimension extent = mapScroller.getViewport().getExtentSize();
+                    if (extent.width <= 0 || extent.height <= 0 || mapView.sizeX <= 0 || mapView.sizeY <= 0) {
+                        return;
+                    }
+
+                    float zoom = Math.min(extent.width / (float) mapView.sizeX, extent.height / (float) mapView.sizeY);
+                    zoom = Math.clamp(zoom, WorldMapView.MIN_ZOOM * WorldMapView.ZOOM_RATIO, WorldMapView.MAX_ZOOM * WorldMapView.ZOOM_RATIO);
+
+                    fitted = true;
+                    int fittedZoom = Math.clamp((int) Math.floor(zoom / WorldMapView.ZOOM_RATIO), WorldMapView.MIN_ZOOM, WorldMapView.MAX_ZOOM);
+                    zoomSlider.setMinimum(fittedZoom);
+                    zoomSlider.setValue(fittedZoom);
+                }));
             }
         });
         pane.add(mapAndPropsSplitter, JideBoxLayout.VARY);
-
-        zoomSlider.addChangeListener(new ChangeListener() {
-            @Override
-            public void stateChanged(ChangeEvent e) {
-
-                Rectangle view = vPort.getViewRect();
-
-                float oldZoomLevel = mapView.zoomLevel;
-                mapView.zoomLevel = zoomSlider.getValue() * WorldMapView.ZOOM_RATIO;
-
-                int newCenterX = (int) (view.getCenterX() / oldZoomLevel * mapView.zoomLevel);
-                int newCenterY = (int) (view.getCenterY() / oldZoomLevel * mapView.zoomLevel);
-
-                view.x = newCenterX - (view.width / 2);
-                view.y = newCenterY - (view.height / 2);
-
-                mapView.scrollRectToVisible(view);
-                mapView.revalidate();
-                mapView.repaint();
-            }
-        });
 
         MouseAdapter mouseListener = new MouseAdapter() {
             final int skipRecomputeDefault = 5;

--- a/src/com/gpl/rpg/atcontentstudio/ui/map/WorldMapEditor.java
+++ b/src/com/gpl/rpg/atcontentstudio/ui/map/WorldMapEditor.java
@@ -109,6 +109,40 @@ public class WorldMapEditor extends Editor implements FieldUpdateListener {
         editorPane.setText(text);
     }
 
+    private void applyZoom(JViewport viewport, JLabel zoomValueLabel, int newZoom, Point anchorPoint) {
+        Point viewPosition = viewport.getViewPosition();
+        float oldZoomLevel = mapView.zoomLevel;
+        mapView.zoomLevel = newZoom * WorldMapView.ZOOM_RATIO;
+        zoomValueLabel.setText(String.format(java.util.Locale.ROOT, "%.2fx", mapView.zoomLevel));
+
+        // Use the anchor point to keep the same point in the map under the mouse cursor after zooming
+        if (anchorPoint != null) {
+            int anchorXInMap = viewPosition.x + anchorPoint.x;
+            int anchorYInMap = viewPosition.y + anchorPoint.y;
+            if (anchorXInMap >= 0 && anchorYInMap >= 0 && anchorXInMap < mapView.getWidth() && anchorYInMap < mapView.getHeight()) {
+                double anchorMapX = anchorXInMap / oldZoomLevel;
+                double anchorMapY = anchorYInMap / oldZoomLevel;
+                viewPosition.x = (int) Math.round(anchorMapX * mapView.zoomLevel - anchorPoint.x);
+                viewPosition.y = (int) Math.round(anchorMapY * mapView.zoomLevel - anchorPoint.y);
+            } else {
+                anchorPoint = null;
+            }
+        }
+
+        // If zooming from a point outside the map, center the view on the map instead
+        if (anchorPoint == null) {
+            Rectangle view = viewport.getViewRect();
+            int newCenterX = Math.round((float) view.getCenterX() / oldZoomLevel * mapView.zoomLevel);
+            int newCenterY = Math.round((float) view.getCenterY() / oldZoomLevel * mapView.zoomLevel);
+            viewPosition.x = newCenterX - (view.width / 2);
+            viewPosition.y = newCenterY - (view.height / 2);
+        }
+
+        viewport.setViewPosition(viewPosition);
+        mapView.revalidate();
+        mapView.repaint();
+    }
+
 
     @SuppressWarnings("unchecked")
     private JPanel buildSegmentTab(final WorldmapSegment worldmap) {
@@ -266,41 +300,16 @@ public class WorldMapEditor extends Editor implements FieldUpdateListener {
         setCurrentSelectionModel(msmListModel, msmListSelectionModel);
 
         final ChangeListener zoomChangeListener = e -> {
-            Rectangle view = vPort.getViewRect();
-
-            float oldZoomLevel = mapView.zoomLevel;
-            mapView.zoomLevel = zoomSlider.getValue() * WorldMapView.ZOOM_RATIO;
-            zoomValueLabel.setText(String.format(java.util.Locale.ROOT, "%.2fx", mapView.zoomLevel));
-
-            int newCenterX = (int) (view.getCenterX() / oldZoomLevel * mapView.zoomLevel);
-            int newCenterY = (int) (view.getCenterY() / oldZoomLevel * mapView.zoomLevel);
-
-            view.x = newCenterX - (view.width / 2);
-            view.y = newCenterY - (view.height / 2);
-
-            mapView.scrollRectToVisible(view);
-            mapView.revalidate();
-            mapView.repaint();
+           applyZoom(vPort, zoomValueLabel, zoomSlider.getValue(), vPort.getMousePosition());
         };
 
         zoomSlider.addChangeListener(zoomChangeListener);
         mapScroller.setWheelScrollingEnabled(false);
-        mapView.addMouseWheelListener(e -> {
-            Point mouse = e.getPoint();
-            Rectangle view = vPort.getViewRect();
-            int anchorX = view.x + mouse.x;
-            int anchorY = view.y + mouse.y;
-
+        vPort.addMouseWheelListener(e -> {
             int newZoom = zoomSlider.getValue() - (e.getWheelRotation() * WorldMapView.INC_ZOOM);
-            newZoom = Math.max(zoomSlider.getMinimum(), Math.min(WorldMapView.MAX_ZOOM, newZoom));
+            newZoom = Math.clamp(newZoom, zoomSlider.getMinimum(), WorldMapView.MAX_ZOOM);
             if (newZoom != zoomSlider.getValue()) {
-                float oldZoomLevel = mapView.zoomLevel;
-                float nextZoomLevel = newZoom * WorldMapView.ZOOM_RATIO;
-                int newViewX = Math.round(anchorX * nextZoomLevel / oldZoomLevel - mouse.x);
-                int newViewY = Math.round(anchorY * nextZoomLevel / oldZoomLevel - mouse.y);
                 zoomSlider.setValue(newZoom);
-                view.setLocation(newViewX, newViewY);
-                mapView.scrollRectToVisible(view);
             }
             e.consume();
         });

--- a/src/com/gpl/rpg/atcontentstudio/ui/map/WorldMapView.java
+++ b/src/com/gpl/rpg/atcontentstudio/ui/map/WorldMapView.java
@@ -211,39 +211,59 @@ public class WorldMapView extends JComponent implements Scrollable {
         }
     }
 
+    /**
+     * Renders a single map into an offscreen image before compositing it into the world map.
+     *
+     * @param map the map to render
+     * @param templateGraphics graphics context used to copy rendering hints
+     * @return the rendered map image
+     */
     private BufferedImage renderMapOffscreen(TMXMap map, Graphics2D templateGraphics) {
-                int mapWidth = Math.max(1, map.tmxMap.getWidth() * map.tmxMap.getTileWidth());
-                int mapHeight = Math.max(1, map.tmxMap.getHeight() * map.tmxMap.getTileHeight());
-                BufferedImage offscreen = new BufferedImage(mapWidth, mapHeight, BufferedImage.TYPE_INT_ARGB);
+        int mapWidth = Math.max(1, map.tmxMap.getWidth() * map.tmxMap.getTileWidth());
+        int mapHeight = Math.max(1, map.tmxMap.getHeight() * map.tmxMap.getTileHeight());
+        BufferedImage offscreen = new BufferedImage(mapWidth, mapHeight, BufferedImage.TYPE_INT_ARGB);
 
-                Graphics2D offG = offscreen.createGraphics();
-                try {
-                    offG.setRenderingHints(templateGraphics.getRenderingHints());
-                    offG.setClip(0, 0, mapWidth, mapHeight);
-                    paintMapContents(offG, map);
-                    if (map.colorFilter != null && map.colorFilter != TMXMap.ColorFilter.none) {
-                        MapColorFilters.applyColorFilter(map.colorFilter, offscreen);
-                    }
-                } finally {
-                    offG.dispose();
-                }
+        Graphics2D offG = offscreen.createGraphics();
+        try {
+            offG.setRenderingHints(templateGraphics.getRenderingHints());
+            offG.setClip(0, 0, mapWidth, mapHeight);
+            paintMapContents(offG, map);
+            if (map.colorFilter != null && map.colorFilter != TMXMap.ColorFilter.none) {
+                MapColorFilters.applyColorFilter(map.colorFilter, offscreen);
+            }
+        } finally {
+            offG.dispose();
+        }
 
-                return offscreen;
+        return offscreen;
     }
 
+    /**
+     * Paints the visible tile and object layers for a single map onto the provided graphics.
+     *
+     * @param g2 graphics context to paint into
+     * @param map map whose layers should be rendered
+     */
     private void paintMapContents(Graphics2D g2, TMXMap map) {
-                MapRenderer renderer = new OrthogonalRenderer(map.tmxMap);
+        MapRenderer renderer = new OrthogonalRenderer(map.tmxMap);
 
-                for (tiled.core.MapLayer layer : map.tmxMap) {
-                    if (layer instanceof tiled.core.TileLayer && layer.isVisible()) {
-                        if (layer.getName().equalsIgnoreCase("walkable")) continue;
-                        renderer.paintTileLayer(g2, (tiled.core.TileLayer) layer);
-                    } else if (layer instanceof tiled.core.ObjectGroup) {
-                        paintObjectGroup(g2, map, (tiled.core.ObjectGroup) layer);
-                    }
-                }
+        for (tiled.core.MapLayer layer : map.tmxMap) {
+            if (layer instanceof tiled.core.TileLayer && layer.isVisible()) {
+                if (layer.getName().equalsIgnoreCase("walkable")) continue;
+                renderer.paintTileLayer(g2, (tiled.core.TileLayer) layer);
+            } else if (layer instanceof tiled.core.ObjectGroup) {
+                paintObjectGroup(g2, map, (tiled.core.ObjectGroup) layer);
+            }
+        }
     }
 
+    /**
+     * Paints the visible objects from one object group.
+     *
+     * @param g2d graphics context to paint into
+     * @param map map that owns the object group
+     * @param layer the object group to render
+     */
     private void paintObjectGroup(Graphics2D g2d, TMXMap map, tiled.core.ObjectGroup layer) {
         for (MapObjectGroup group : map.groups) {
             if (group.tmxGroup == layer) {
@@ -260,6 +280,13 @@ public class WorldMapView extends JComponent implements Scrollable {
         }
     }
 
+    /**
+     * Draws a highlighted representation of a map object.
+     *
+     * @param object the object to draw
+     * @param g2d graphics context to paint into
+     * @param color base highlight color
+     */
     private void drawObject(MapObject object, Graphics2D g2d, Color color) {
         g2d.setPaint(color);
         g2d.drawRect(object.x + 1, object.y + 1, object.w - 3, object.h - 3);


### PR DESCRIPTION
This PR refactors zoom support in worldmap, allowing mouse wheel zooming, moving the slider, and setting a sensible default zoom clamped to mininum full screen.  If anyone needs to zoom out further (making things smaller), that can be reverted, but it provides for a better UI in general.

### Copilot Summary
The most significant changes include a more intuitive zoom slider with mouse wheel support and anchor-point zooming, improved layout for zoom controls, and the addition of detailed JavaDoc comments to clarify rendering methods.

**World Map Editor UI and Zoom Enhancements:**

* The zoom slider in `WorldMapEditor` has been redesigned to be horizontal, with a live zoom factor label (1.0x = 1:1 pixel scaling).  The zoom slider is now grouped with zoom controls in a new header pane for better layout.
* Zooming can now be performed using the mouse wheel, with the zoom anchored to the mouse cursor position for a more intuitive experience. The zoom value is clamped, and the viewport adjusts to keep the anchor point (or the map center) in place. [[1]](diffhunk://#diff-6c07b4f495ab6e832e0d004eb7f5b9c372aead12346e58e680811004b90c42bdR112-R185) [[2]](diffhunk://#diff-6c07b4f495ab6e832e0d004eb7f5b9c372aead12346e58e680811004b90c42bdL240-R352)
* The initial zoom level is automatically fitted to the viewport when the editor is first displayed, ensuring the map is always visible and optimally scaled at startup (i.e., fitting to available viewport)

**Code Documentation Improvements:**

* Added detailed JavaDoc comments to `WorldMapView` methods such as `renderMapOffscreen`, `paintMapContents`, `paintObjectGroup`, and `drawObject` to clarify their responsibilities and parameters. [[1]](diffhunk://#diff-074e190b788476dd58b87af00b0274e8a34f3ff7e11fd3d05e360331edc3192dR214-R220) [[2]](diffhunk://#diff-074e190b788476dd58b87af00b0274e8a34f3ff7e11fd3d05e360331edc3192dR241-R246) [[3]](diffhunk://#diff-074e190b788476dd58b87af00b0274e8a34f3ff7e11fd3d05e360331edc3192dR260-R266) [[4]](diffhunk://#diff-074e190b788476dd58b87af00b0274e8a34f3ff7e11fd3d05e360331edc3192dR283-R289)
