### PR TITLE
Win console

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ Or run the built jar directly:
 java -jar build/libs/ATContentStudio-<version>-all.jar
 ```
 
+On Windows, add `--show-console` to allocate and attach a console window.
+
 ## Build
 
 On Linux/macOS:

--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ repositories {
 // Local jars are checked into lib/ and used as implementation/test dependencies.
 dependencies {
     implementation fileTree(dir: 'lib', include: ['*.jar'], exclude: ['junit-*.jar', '*-sources.jar'])
+    implementation 'net.java.dev.jna:jna:5.15.0' // Needed for Windows console support
 
     testImplementation files('lib/junit-4.10.jar')
 }

--- a/src/com/gpl/rpg/atcontentstudio/ATContentStudio.java
+++ b/src/com/gpl/rpg/atcontentstudio/ATContentStudio.java
@@ -621,7 +621,7 @@ public class ATContentStudio {
                     "Notes:",
                     "  - If <target> ends with .zip, ATCS exports a zip package.",
                     "  - Otherwise, <target> must be an existing game-source directory.",
-                    "  - --show-console allocates and attaches a Windows console window.",
+                    "  - --show-console allocates and attaches a console window (Windows platform only).",
                     "  - --skip-lock-check bypasses single-instance workspace locking.",
                     "  - --ignore-config ignores saved global config and behaves like a fresh install for this run.",
             }

--- a/src/com/gpl/rpg/atcontentstudio/ATContentStudio.java
+++ b/src/com/gpl/rpg/atcontentstudio/ATContentStudio.java
@@ -20,6 +20,8 @@ import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.io.BufferedReader;
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.PrintStream;
@@ -48,6 +50,7 @@ public class ATContentStudio {
     private static final String QUIET_ARGUMENT = "--quiet";
     private static final String SKIP_LOCK_CHECK_ARGUMENT = "--skip-lock-check";
     private static final String IGNORE_EXISTING_CONFIG_ARGUMENT = "--ignore-config";
+    private static final String SHOW_CONSOLE_ARGUMENT = "--show-console";
     private static final String RESTART_HELPER_ARGUMENT = "--restart-helper";
     private static final String WAIT_FOR_PID_ARGUMENT = "--wait-for-pid";
     private static final String HELP_ARGUMENT = "--help";
@@ -105,6 +108,16 @@ public class ATContentStudio {
             printCommandLineUsage(System.out);
             System.exit(0);
             return;
+        }
+
+        if (startupArguments.showConsole) {
+            if (isWindows()) {
+                if (!enableWindowsConsole()) {
+                    System.err.println("Failed to allocate a console window.");
+                }
+            } else {
+                System.err.println("--show-console is only supported on Windows.");
+            }
         }
 
         if (startupArguments.isHeadlessExportRequested()) {
@@ -558,20 +571,57 @@ public class ATContentStudio {
         ConfigCache.setLatestWorkspace(workspaceRoot);
     }
 
+    private static boolean enableWindowsConsole() {
+        if (WindowsConsole.KERNEL32.AttachConsole(WindowsConsole.ATTACH_PARENT_PROCESS) || WindowsConsole.KERNEL32.AllocConsole()) {
+            redirectStandardStreamsToConsole();
+            return true;
+        }
+        return false;
+    }
+
+    private static boolean isWindows() {
+        return System.getProperty("os.name", "").toLowerCase(Locale.ROOT).contains("win");
+    }
+
+    private static void redirectStandardStreamsToConsole() {
+        try {
+            PrintStream consoleOut = new PrintStream(new FileOutputStream("CONOUT$"), true);
+            System.setOut(consoleOut);
+            System.setErr(consoleOut);
+            System.setIn(new FileInputStream("CONIN$"));
+        } catch (IOException e) {
+            throw new IllegalStateException("Console was allocated but standard streams could not be redirected.", e);
+        }
+    }
+
+    private static final class WindowsConsole {
+        private static final int ATTACH_PARENT_PROCESS = -1;
+        private static final Kernel32 KERNEL32 = com.sun.jna.Native.load("kernel32", Kernel32.class);
+
+        private WindowsConsole() {
+        }
+
+        private interface Kernel32 extends com.sun.jna.Library {
+            boolean AttachConsole(int dwProcessId);
+            boolean AllocConsole();
+        }
+    }
+
     @Command(
             name = "ATContentStudio",
             sortOptions = false,
             customSynopsis = {
                     "  GUI mode:",
-                    "    ATContentStudio [--help] [--workspace <workspace>] [--export-target <path>] [--skip-lock-check] [--ignore-config]",
+                    "    ATContentStudio [--help] [--show-console] [--workspace <workspace>] [--export-target <path>] [--skip-lock-check] [--ignore-config]",
                     "  Headless export mode:",
-                    "    ATContentStudio [--help] --workspace <workspace> --project <project-name> --export-target <target> [-q|--quiet] [--skip-lock-check] [--ignore-config]"
+                    "    ATContentStudio [--help] [--show-console] --workspace <workspace> --project <project-name> --export-target <target> [-q|--quiet] [--skip-lock-check] [--ignore-config]"
             },
             description = "Launches Andor's Trail Content Studio in GUI mode or headless export mode.",
             footer = {
                     "Notes:",
                     "  - If <target> ends with .zip, ATCS exports a zip package.",
                     "  - Otherwise, <target> must be an existing game-source directory.",
+                    "  - --show-console allocates and attaches a Windows console window.",
                     "  - --skip-lock-check bypasses single-instance workspace locking.",
                     "  - --ignore-config ignores saved global config and behaves like a fresh install for this run.",
             }
@@ -594,6 +644,9 @@ public class ATContentStudio {
 
         @Option(names = IGNORE_EXISTING_CONFIG_ARGUMENT, description = "Ignores saved global config and behaves like a fresh install for this run.")
         private boolean ignoreExistingConfig;
+
+        @Option(names = SHOW_CONSOLE_ARGUMENT, description = "Allocates and attaches a Windows console window.")
+        private boolean showConsole;
 
         @Option(names = RESTART_HELPER_ARGUMENT, hidden = true)
         private boolean restartHelper;


### PR DESCRIPTION
This pull request adds support for a new `--show-console` command-line argument, enabling users to allocate and attach a console window when running ATContentStudio on Windows. This is particularly useful for viewing standard output and error streams, which are not visible by default in GUI applications on Windows. The implementation includes platform checks, stream redirection, and updates to the documentation and help output.

**New Feature: Windows Console Support**
- Added a `--show-console` command-line argument that allocates and attaches a console window on Windows, redirecting standard input/output/error streams to the console. This feature is only available on Windows and prints a warning if used on other platforms. [[1]](diffhunk://#diff-9bee77cbe5cf1da2cdcff72f951577aacf0eca305b8e604f32f7dce7471558cbR53) [[2]](diffhunk://#diff-9bee77cbe5cf1da2cdcff72f951577aacf0eca305b8e604f32f7dce7471558cbR113-R122) [[3]](diffhunk://#diff-9bee77cbe5cf1da2cdcff72f951577aacf0eca305b8e604f32f7dce7471558cbR574-R624) [[4]](diffhunk://#diff-9bee77cbe5cf1da2cdcff72f951577aacf0eca305b8e604f32f7dce7471558cbR648-R650)

**Documentation Updates**
- Updated the `README.md` to document the new `--show-console` option for Windows users.
- Updated the command-line help and synopsis to include `--show-console`, clarifying its purpose and platform restriction.