### PR TITLE
Worldmap cache

### DIFF
--- a/src/com/gpl/rpg/atcontentstudio/model/WorkspaceSettings.java
+++ b/src/com/gpl/rpg/atcontentstudio/model/WorkspaceSettings.java
@@ -24,6 +24,9 @@ public class WorkspaceSettings {
     public Setting<Boolean> useSystemDefaultMapEditor = new PrimitiveSetting<Boolean>("useSystemDefaultMapEditor", DEFAULT_USE_SYS_MAP_EDITOR);
     public static String DEFAULT_MAP_EDITOR_COMMAND = "tiled";
     public Setting<String> mapEditorCommand = new PrimitiveSetting<String>("mapEditorCommand", DEFAULT_MAP_EDITOR_COMMAND);
+    // When enabled, world map zoom only reacts to Ctrl + mouse wheel.
+    public static Boolean DEFAULT_ZOOM_WORLD_MAP_ONLY_WITH_CTRL = false;
+    public Setting<Boolean> zoomWorldMapOnlyWithCtrl = new PrimitiveSetting<Boolean>("zoomWorldMapOnlyWithCtrl", DEFAULT_ZOOM_WORLD_MAP_ONLY_WITH_CTRL);
 
     public static Boolean DEFAULT_USE_SYS_IMG_VIEWER = true;
     public Setting<Boolean> useSystemDefaultImageViewer = new PrimitiveSetting<Boolean>("useSystemDefaultImageViewer", DEFAULT_USE_SYS_IMG_VIEWER);
@@ -46,6 +49,7 @@ public class WorkspaceSettings {
         this.parent = parent;
         settings.add(useSystemDefaultMapEditor);
         settings.add(mapEditorCommand);
+        settings.add(zoomWorldMapOnlyWithCtrl);
         settings.add(useSystemDefaultImageViewer);
         settings.add(useSystemDefaultImageEditor);
         settings.add(imageEditorCommand);

--- a/src/com/gpl/rpg/atcontentstudio/model/maps/TMXMap.java
+++ b/src/com/gpl/rpg/atcontentstudio/model/maps/TMXMap.java
@@ -54,6 +54,8 @@ public class TMXMap extends GameDataElement {
 
     public boolean changedOnDisk = false;
     public int dismissNextChangeNotif = 0;
+    // Bumps whenever the rendered TMX content changes so view caches can invalidate lazily.
+    private long renderGeneration = 0;
 
     public TMXMap(TMXMapSet parent, File f) {
         this.parent = parent;
@@ -177,6 +179,7 @@ public class TMXMap extends GameDataElement {
 
     @Override
     public void childrenChanged(List<ProjectTreeNode> path) {
+        renderGeneration++;
         path.add(0, this);
         parent.childrenChanged(path);
     }
@@ -339,6 +342,7 @@ public class TMXMap extends GameDataElement {
 
     public void addLayer(tiled.core.MapLayer layer) {
         tmxMap.addLayer(layer);
+        renderGeneration++;
         if (layer instanceof tiled.core.ObjectGroup) {
             groups.add(new MapObjectGroup((tiled.core.ObjectGroup) layer, this));
         }
@@ -346,6 +350,7 @@ public class TMXMap extends GameDataElement {
 
     public void removeLayer(tiled.core.MapLayer layer) {
         tmxMap.removeLayer(tmxMap.getLayerIndex(layer));
+        renderGeneration++;
         if (layer instanceof tiled.core.ObjectGroup) {
             MapObjectGroup toRemove = null;
             for (MapObjectGroup group : groups) {
@@ -405,6 +410,7 @@ public class TMXMap extends GameDataElement {
 
     public void reload() {
         tmxMap = null;
+        renderGeneration++;
         for (Spritesheet s : usedSpritesheets) {
             s.elementChanged(this, null);
         }
@@ -447,6 +453,15 @@ public class TMXMap extends GameDataElement {
         for (MapChangedOnDiskListener l : listeners) {
             l.mapReloaded();
         }
+    }
+
+    /**
+     * Returns the current render generation for cache invalidation.
+     *
+     * @return monotonically increasing render generation
+     */
+    public long getRenderGeneration() {
+        return renderGeneration;
     }
 
     public void mapChangedOnDisk() {

--- a/src/com/gpl/rpg/atcontentstudio/ui/WorkspaceSettingsEditor.java
+++ b/src/com/gpl/rpg/atcontentstudio/ui/WorkspaceSettingsEditor.java
@@ -17,6 +17,8 @@ public class WorkspaceSettingsEditor extends JDialog {
 
     JRadioButton useSystemDefaultMapEditorButton, useCustomMapEditorButton;
     JTextField mapEditorCommandField;
+    // Checkbox for the world map Ctrl-only zoom preference.
+    JCheckBox zoomWorldMapOnlyWithCtrlBox;
 
     JRadioButton useSystemDefaultImageViewerButton, useSystemDefaultImageEditorButton, useCustomImageEditorButton;
     JTextField imageEditorCommandField;
@@ -44,6 +46,7 @@ public class WorkspaceSettingsEditor extends JDialog {
 
 
         pane.add(getExternalToolsPane(), JideBoxLayout.FIX);
+        pane.add(getEditorBehaviorPane(), JideBoxLayout.FIX);
         pane.add(getInternetPane(), JideBoxLayout.FIX);
         pane.add(new JPanel(), JideBoxLayout.VARY);
 
@@ -190,11 +193,22 @@ public class WorkspaceSettingsEditor extends JDialog {
         return pane;
     }
 
+    public JPanel getEditorBehaviorPane() {
+        CollapsiblePanel pane = new CollapsiblePanel("Editor behavior");
+        pane.setLayout(new JideBoxLayout(pane, JideBoxLayout.PAGE_AXIS));
+
+        zoomWorldMapOnlyWithCtrlBox = new JCheckBox("Use Ctrl+Wheel to zoom World Map");
+        pane.add(zoomWorldMapOnlyWithCtrlBox, JideBoxLayout.FIX);
+
+        return pane;
+    }
+
     public void loadFromModel() {
         //Tiled
         useSystemDefaultMapEditorButton.setSelected(settings.useSystemDefaultMapEditor.getCurrentValue());
         useCustomMapEditorButton.setSelected(!settings.useSystemDefaultMapEditor.getCurrentValue());
         mapEditorCommandField.setText(settings.mapEditorCommand.getCurrentValue());
+        zoomWorldMapOnlyWithCtrlBox.setSelected(settings.zoomWorldMapOnlyWithCtrl.getCurrentValue());
         //Images
         useSystemDefaultImageViewerButton.setSelected(settings.useSystemDefaultImageViewer.getCurrentValue());
         useSystemDefaultImageEditorButton.setSelected(settings.useSystemDefaultImageEditor.getCurrentValue());
@@ -220,6 +234,7 @@ public class WorkspaceSettingsEditor extends JDialog {
         //Tiled
         settings.useSystemDefaultMapEditor.setCurrentValue(useSystemDefaultMapEditorButton.isSelected());
         settings.mapEditorCommand.setCurrentValue(mapEditorCommandField.getText());
+        settings.zoomWorldMapOnlyWithCtrl.setCurrentValue(zoomWorldMapOnlyWithCtrlBox.isSelected());
         //Images
         settings.useSystemDefaultImageViewer.setCurrentValue(useSystemDefaultImageViewerButton.isSelected());
         settings.useSystemDefaultImageEditor.setCurrentValue(useSystemDefaultImageEditorButton.isSelected());

--- a/src/com/gpl/rpg/atcontentstudio/ui/map/TMXMapEditor.java
+++ b/src/com/gpl/rpg/atcontentstudio/ui/map/TMXMapEditor.java
@@ -1852,7 +1852,6 @@ public class TMXMapEditor extends Editor implements TMXMap.MapChangedOnDiskListe
                 if (selectedLayer instanceof tiled.core.ObjectGroup) {
                     map.getGroup((tiled.core.ObjectGroup) selectedLayer).visible = layerVisibleBox.isSelected();
                 }
-                modified = false;
                 tmxViewer.revalidate();
                 tmxViewer.repaint();
             } else if (source == groupActiveForNewGame) {

--- a/src/com/gpl/rpg/atcontentstudio/ui/map/WorldMapEditor.java
+++ b/src/com/gpl/rpg/atcontentstudio/ui/map/WorldMapEditor.java
@@ -5,6 +5,7 @@ import com.gpl.rpg.atcontentstudio.Notification;
 import com.gpl.rpg.atcontentstudio.model.GameDataElement;
 import com.gpl.rpg.atcontentstudio.model.GameSource;
 import com.gpl.rpg.atcontentstudio.model.ProjectTreeNode;
+import com.gpl.rpg.atcontentstudio.model.Workspace;
 import com.gpl.rpg.atcontentstudio.model.maps.TMXMap;
 import com.gpl.rpg.atcontentstudio.model.maps.Worldmap;
 import com.gpl.rpg.atcontentstudio.model.maps.WorldmapSegment;
@@ -335,8 +336,29 @@ public class WorldMapEditor extends Editor implements FieldUpdateListener {
         };
 
         zoomSlider.addChangeListener(zoomChangeListener);
-        mapScroller.setWheelScrollingEnabled(false);
-        vPort.addMouseWheelListener(e -> {
+        mapScroller.setWheelScrollingEnabled(true);
+
+        // Remove any existing wheel listener on mapscroller
+        MouseWheelListener defaultWheelListener = null;
+        MouseWheelListener[] wheelListeners = mapScroller.getMouseWheelListeners();
+        if (wheelListeners.length > 0) {
+            defaultWheelListener = wheelListeners[0];
+            mapScroller.removeMouseWheelListener(defaultWheelListener);
+        }
+
+        // Set a new wheel listener on the mapscroller that checks Prefs option for control, and if
+        // not, pass the event on so the scroller moves up/down)
+        final MouseWheelListener finalDefaultWheelListener = defaultWheelListener;
+        mapScroller.addMouseWheelListener(e -> {
+            // Read the preference at event time so changes apply without reopening the editor.
+            boolean ctrlRequired = Workspace.activeWorkspace != null
+                    && Workspace.activeWorkspace.settings.zoomWorldMapOnlyWithCtrl.getCurrentValue();
+            if (ctrlRequired && !e.isControlDown()) {
+                if (finalDefaultWheelListener != null) {
+                    finalDefaultWheelListener.mouseWheelMoved(e);
+                }
+                return;
+            }
             int newZoom = zoomSlider.getValue() - (e.getWheelRotation() * WorldMapView.INC_ZOOM);
             newZoom = Math.clamp(newZoom, zoomSlider.getMinimum(), WorldMapView.MAX_ZOOM);
             if (newZoom != zoomSlider.getValue()) {

--- a/src/com/gpl/rpg/atcontentstudio/ui/map/WorldMapEditor.java
+++ b/src/com/gpl/rpg/atcontentstudio/ui/map/WorldMapEditor.java
@@ -5,7 +5,6 @@ import com.gpl.rpg.atcontentstudio.Notification;
 import com.gpl.rpg.atcontentstudio.model.GameDataElement;
 import com.gpl.rpg.atcontentstudio.model.GameSource;
 import com.gpl.rpg.atcontentstudio.model.ProjectTreeNode;
-import com.gpl.rpg.atcontentstudio.model.SaveEvent;
 import com.gpl.rpg.atcontentstudio.model.maps.TMXMap;
 import com.gpl.rpg.atcontentstudio.model.maps.Worldmap;
 import com.gpl.rpg.atcontentstudio.model.maps.WorldmapSegment;
@@ -45,6 +44,12 @@ public class WorldMapEditor extends Editor implements FieldUpdateListener {
     public String mapBeingAddedID = null;
     WorldMapView mapView = null;
     WorldmapSegment.NamedArea selectedLabel = null;
+
+    // Log-scale zoom endpoints expressed as actual zoom factors.
+    private static final float MIN_ZOOM_LEVEL = WorldMapView.MIN_ZOOM * WorldMapView.ZOOM_RATIO;
+    private static final float MAX_ZOOM_LEVEL = WorldMapView.MAX_ZOOM * WorldMapView.ZOOM_RATIO;
+    // Current lower zoom bound; updated after fitting the map to the viewport.
+    private float zoomFloor = MIN_ZOOM_LEVEL;
 
     MapSegmentMapsListModel msmListModel = null;
     ListSelectionModel msmListSelectionModel = null;
@@ -112,7 +117,7 @@ public class WorldMapEditor extends Editor implements FieldUpdateListener {
     private void applyZoom(JViewport viewport, JLabel zoomValueLabel, int newZoom, Point anchorPoint) {
         Point viewPosition = viewport.getViewPosition();
         float oldZoomLevel = mapView.zoomLevel;
-        mapView.zoomLevel = newZoom * WorldMapView.ZOOM_RATIO;
+        mapView.zoomLevel = sliderValueToZoom(newZoom);
         zoomValueLabel.setText(String.format(java.util.Locale.ROOT, "%.2fx", mapView.zoomLevel));
 
         // Use the anchor point to keep the same point in the map under the mouse cursor after zooming
@@ -143,6 +148,32 @@ public class WorldMapEditor extends Editor implements FieldUpdateListener {
         mapView.repaint();
     }
 
+    /**
+     * Converts a slider position to a logarithmically scaled zoom factor.
+     *
+     * @param sliderValue the current zoom slider value
+     * @return the zoom factor to apply to the world view
+     */
+    private float sliderValueToZoom(int sliderValue) {
+        float clamped = Math.clamp(sliderValue, WorldMapView.MIN_ZOOM, WorldMapView.MAX_ZOOM);
+        double t = (clamped - WorldMapView.MIN_ZOOM) / (double) (WorldMapView.MAX_ZOOM - WorldMapView.MIN_ZOOM);
+        return (float) (zoomFloor * Math.pow(MAX_ZOOM_LEVEL / zoomFloor, t));
+    }
+
+    /**
+     * Converts a zoom factor back into the matching slider position.
+     *
+     * @param zoomLevel the zoom factor currently applied
+     * @return the slider value that represents the zoom factor
+     */
+    private int zoomToSliderValue(float zoomLevel) {
+        float clamped = Math.clamp(zoomLevel, zoomFloor, MAX_ZOOM_LEVEL);
+        double t = Math.log(clamped / zoomFloor) / Math.log(MAX_ZOOM_LEVEL / zoomFloor);
+        return Math.clamp((int) Math.round(WorldMapView.MIN_ZOOM + t * (WorldMapView.MAX_ZOOM - WorldMapView.MIN_ZOOM)),
+                WorldMapView.MIN_ZOOM,
+                WorldMapView.MAX_ZOOM);
+    }
+
 
     @SuppressWarnings("unchecked")
     private JPanel buildSegmentTab(final WorldmapSegment worldmap) {
@@ -154,7 +185,7 @@ public class WorldMapEditor extends Editor implements FieldUpdateListener {
         JScrollPane mapScroller = new JScrollPane(mapView);
         final JViewport vPort = mapScroller.getViewport();
 
-        final JSlider zoomSlider = new JSlider(WorldMapView.MIN_ZOOM, WorldMapView.MAX_ZOOM, (int) (mapView.zoomLevel / WorldMapView.ZOOM_RATIO));
+        final JSlider zoomSlider = new JSlider(WorldMapView.MIN_ZOOM, WorldMapView.MAX_ZOOM, zoomToSliderValue(mapView.zoomLevel));
         zoomSlider.setSnapToTicks(true);
         zoomSlider.setMinorTickSpacing(WorldMapView.INC_ZOOM);
         zoomSlider.setPaintTicks(false);
@@ -340,12 +371,11 @@ public class WorldMapEditor extends Editor implements FieldUpdateListener {
                     }
 
                     float zoom = Math.min(extent.width / (float) mapView.sizeX, extent.height / (float) mapView.sizeY);
-                    zoom = Math.clamp(zoom, WorldMapView.MIN_ZOOM * WorldMapView.ZOOM_RATIO, WorldMapView.MAX_ZOOM * WorldMapView.ZOOM_RATIO);
+                    zoom = Math.clamp(zoom, MIN_ZOOM_LEVEL, MAX_ZOOM_LEVEL);
 
                     fitted = true;
-                    int fittedZoom = Math.clamp((int) Math.floor(zoom / WorldMapView.ZOOM_RATIO), WorldMapView.MIN_ZOOM, WorldMapView.MAX_ZOOM);
-                    zoomSlider.setMinimum(fittedZoom);
-                    zoomSlider.setValue(fittedZoom);
+                    zoomFloor = zoom;
+                    zoomSlider.setValue(zoomSlider.getMinimum());
                 }));
             }
         });

--- a/src/com/gpl/rpg/atcontentstudio/ui/map/WorldMapView.java
+++ b/src/com/gpl/rpg/atcontentstudio/ui/map/WorldMapView.java
@@ -42,6 +42,8 @@ public class WorldMapView extends JComponent implements Scrollable {
     int sizeX = 0, sizeY = 0;
     int offsetX = 0, offsetY = 0;
 
+    // Cached native-resolution renders for each TMX map, keyed by map id.
+    private final Map<String, CachedMapRender> renderedMapCache = new HashMap<String, CachedMapRender>();
 
     static final Color selectOutlineColor = new Color(255, 0, 0);
     static final Stroke selectOutlineStroke = new BasicStroke(4f);
@@ -148,7 +150,7 @@ public class WorldMapView extends JComponent implements Scrollable {
         return event.getPoint();
     }
 
-    private void paintOnGraphics(Graphics2D g2) {
+    private void paintOnGraphics(Graphics2D g2, Rectangle clip) {
         g2.setPaint(new Color(100, 100, 100));
         g2.fillRect(0, 0, sizeX, sizeY);
 
@@ -165,25 +167,28 @@ public class WorldMapView extends JComponent implements Scrollable {
         FontMetrics mifm = g2.getFontMetrics();
         int mapIdLabelHeight = mifm.getHeight();
 
-        for (String s : new HashSet<String>(mapLocations.keySet())) {
+        // Convert the screen clip to world coordinates so we only composite visible maps.
+        Rectangle visibleWorld = getVisibleWorldBounds(clip);
 
-            int x = mapLocations.get(s).x;
-            int y = mapLocations.get(s).y;
+        for (Map.Entry<String, Rectangle> entry : mapLocations.entrySet()) {
+            Rectangle bounds = entry.getValue();
+            if (visibleWorld != null && !visibleWorld.intersects(bounds)) continue;
 
-            TMXMap map = proj.getMap(s);
-            if (map == null) continue;
+            TMXMap map = proj.getMap(entry.getKey());
+            if (map == null || map.tmxMap == null) continue;
 
-            BufferedImage offscreen = renderMapOffscreen(map, g2);
-            g2.drawImage(offscreen, x, y, null);
-
+            BufferedImage offscreen = getRenderedMapImage(map, g2);
+            if (offscreen != null) {
+                g2.drawImage(offscreen, bounds.x, bounds.y, null);
+            }
         }
 
         if (highlightedListModel != null) {
-            outlineFromListModel(g2, highlightedListModel, null, highlightOutlineColor, highlightOutlineStroke, mapIdFont, mapIdLabelHeight);
+            outlineFromListModel(g2, highlightedListModel, null, highlightOutlineColor, highlightOutlineStroke, mapIdFont, mapIdLabelHeight, visibleWorld);
         }
 
         if (selectedListModel != null && selectedSelectionModel != null) {
-            outlineFromListModel(g2, selectedListModel, selectedSelectionModel, selectOutlineColor, selectOutlineStroke, mapIdFont, mapIdLabelHeight);
+            outlineFromListModel(g2, selectedListModel, selectedSelectionModel, selectOutlineColor, selectOutlineStroke, mapIdFont, mapIdLabelHeight, visibleWorld);
         }
 
 
@@ -236,6 +241,29 @@ public class WorldMapView extends JComponent implements Scrollable {
         }
 
         return offscreen;
+    }
+
+    /**
+     * Returns the cached render for a TMX map, rebuilding it when the map generation changes.
+     *
+     * @param map the map to render
+     * @param templateGraphics graphics context used to copy rendering hints
+     * @return a cached or freshly rendered image for the map
+     */
+    private BufferedImage getRenderedMapImage(TMXMap map, Graphics2D templateGraphics) {
+        CachedMapRender cached = renderedMapCache.get(map.id);
+        long generation = map.getRenderGeneration();
+        int mapWidth = Math.max(1, map.tmxMap.getWidth() * map.tmxMap.getTileWidth());
+        int mapHeight = Math.max(1, map.tmxMap.getHeight() * map.tmxMap.getTileHeight());
+
+        if (cached != null && cached.generation == generation && cached.image != null &&
+                cached.image.getWidth() == mapWidth && cached.image.getHeight() == mapHeight) {
+            return cached.image;
+        }
+
+        BufferedImage rendered = renderMapOffscreen(map, templateGraphics);
+        renderedMapCache.put(map.id, new CachedMapRender(generation, rendered));
+        return rendered;
     }
 
     /**
@@ -307,13 +335,16 @@ public class WorldMapView extends JComponent implements Scrollable {
         g2d.drawImage(object.getIcon(), object.x + 2, object.y + 2, null);
     }
 
-    private void outlineFromListModel(Graphics2D g2, ListModel<TMXMap> listModel, ListSelectionModel selectionModel, Color outlineColor, Stroke outlineStroke, Font mapIdFont, int mapIdLabelHeight) {
+    private void outlineFromListModel(Graphics2D g2, ListModel<TMXMap> listModel, ListSelectionModel selectionModel, Color outlineColor, Stroke outlineStroke, Font mapIdFont, int mapIdLabelHeight, Rectangle visibleWorld) {
         for (int i = 0; i < listModel.getSize(); i++) {
             //No selection model ? We want to highlight the whole list.
             if (selectionModel == null || selectionModel.isSelectedIndex(i)) {
                 TMXMap map = listModel.getElementAt(i);
-                int x = mapLocations.get(map.id).x;
-                int y = mapLocations.get(map.id).y;
+                Rectangle bounds = mapLocations.get(map.id);
+                if (bounds == null) continue;
+                if (visibleWorld != null && !visibleWorld.intersects(bounds)) continue;
+                int x = bounds.x;
+                int y = bounds.y;
 
                 g2.translate(x, y);
 
@@ -351,8 +382,7 @@ public class WorldMapView extends JComponent implements Scrollable {
         Graphics2D g2 = (Graphics2D) g.create();
         try {
             g2.scale(zoomLevel, zoomLevel);
-//			g2.drawImage(img, 0, 0, null);
-            paintOnGraphics(g2);
+            paintOnGraphics(g2, g.getClipBounds());
 
         } finally {
             g2.dispose();
@@ -460,6 +490,7 @@ public class WorldMapView extends JComponent implements Scrollable {
 
     public void updateFromModel() {
         mapLocations.clear();
+        renderedMapCache.clear();
         sizeX = sizeY = 0;
         offsetX = worldmap.segmentX * TILE_SIZE;
         offsetY = worldmap.segmentY * TILE_SIZE;
@@ -478,6 +509,23 @@ public class WorldMapView extends JComponent implements Scrollable {
 
             mapLocations.put(s, new Rectangle(x, y, w, h));
         }
+    }
+
+    /**
+     * Converts a screen-space clip rectangle into world coordinates.
+     *
+     * @param clip the component clip in screen coordinates
+     * @return the corresponding world-space bounds
+     */
+    private Rectangle getVisibleWorldBounds(Rectangle clip) {
+        if (clip == null) {
+            clip = new Rectangle(0, 0, Math.max(1, getWidth()), Math.max(1, getHeight()));
+        }
+        int x = (int) Math.floor(clip.x / zoomLevel);
+        int y = (int) Math.floor(clip.y / zoomLevel);
+        int w = (int) Math.ceil((clip.x + clip.width) / zoomLevel) - x;
+        int h = (int) Math.ceil((clip.y + clip.height) / zoomLevel) - y;
+        return new Rectangle(x, y, Math.max(1, w), Math.max(1, h));
     }
 
     public void pushToModel() {
@@ -504,6 +552,18 @@ public class WorldMapView extends JComponent implements Scrollable {
                 continue;
             }
             worldmap.getProject().getMap(id).addBacklink(worldmap);
+        }
+    }
+
+    private static final class CachedMapRender {
+        // Render version taken from TMXMap#getRenderGeneration().
+        private final long generation;
+        // Native-resolution map bitmap reused across paints.
+        private final BufferedImage image;
+
+        private CachedMapRender(long generation, BufferedImage image) {
+            this.generation = generation;
+            this.image = image;
         }
     }
 

--- a/src/com/gpl/rpg/atcontentstudio/ui/map/WorldMapView.java
+++ b/src/com/gpl/rpg/atcontentstudio/ui/map/WorldMapView.java
@@ -22,8 +22,8 @@ public class WorldMapView extends JComponent implements Scrollable {
     private static final long serialVersionUID = -4111374378777093799L;
 
     public static final int TILE_SIZE = 32;
-    public static final int MIN_ZOOM = 5;
-    public static final int MAX_ZOOM = 250;
+    public static final int MIN_ZOOM = 1;
+    public static final int MAX_ZOOM = 500;
     public static final int INC_ZOOM = 5;
     public static final float ZOOM_RATIO = 0.01f;
 


### PR DESCRIPTION
This pull request provides a massive improvement in world map rendering for performance, particular for zooming.  World map rendering logic has been refactored to cache TMX map images and only re-render when necessary. Additionally, the zoom slider now uses a logarithmic scale for smoother zooming, and the zoom range has been expanded, and a Preferences option has been added to require Ctrl to be held while zooming (by default, it will zoom with the wheel alone).

**World map rendering and performance:**

* Implemented a render generation counter in `TMXMap` and a cache in `WorldMapView` to avoid unnecessary re-rendering of map images, improving performance when navigating the world map. The cache is invalidated only when the underlying map changes. [[1]](diffhunk://#diff-ef9b943480ec4a4092594a3c16d242ce3c388025900a6f031428c3e46691c027R57-R58) [[2]](diffhunk://#diff-ef9b943480ec4a4092594a3c16d242ce3c388025900a6f031428c3e46691c027R182) [[3]](diffhunk://#diff-ef9b943480ec4a4092594a3c16d242ce3c388025900a6f031428c3e46691c027R345-R353) [[4]](diffhunk://#diff-ef9b943480ec4a4092594a3c16d242ce3c388025900a6f031428c3e46691c027R413) [[5]](diffhunk://#diff-ef9b943480ec4a4092594a3c16d242ce3c388025900a6f031428c3e46691c027R458-R466) [[6]](diffhunk://#diff-074e190b788476dd58b87af00b0274e8a34f3ff7e11fd3d05e360331edc3192dR45-R46) [[7]](diffhunk://#diff-074e190b788476dd58b87af00b0274e8a34f3ff7e11fd3d05e360331edc3192dL151-R153) [[8]](diffhunk://#diff-074e190b788476dd58b87af00b0274e8a34f3ff7e11fd3d05e360331edc3192dL168-R191)

**New user preference and UI integration:**

* Added a `zoomWorldMapOnlyWithCtrl` setting to `WorkspaceSettings`, allowing users to require holding Ctrl to zoom the world map with the mouse wheel. This setting is exposed in the preferences dialog and is saved/loaded with other workspace options. [[1]](diffhunk://#diff-d4dfa3b3bf00daf452fcbad8a1f867418cf27252b4a2bde3134b95d46936fd37R27-R29) [[2]](diffhunk://#diff-d4dfa3b3bf00daf452fcbad8a1f867418cf27252b4a2bde3134b95d46936fd37R52) [[3]](diffhunk://#diff-2ef33a1041c9f4a0bc1b9373cf036839f6d34c14ace1e5ab0a8f47847c2c65e3R20-R21) [[4]](diffhunk://#diff-2ef33a1041c9f4a0bc1b9373cf036839f6d34c14ace1e5ab0a8f47847c2c65e3R49) [[5]](diffhunk://#diff-2ef33a1041c9f4a0bc1b9373cf036839f6d34c14ace1e5ab0a8f47847c2c65e3R196-R211) [[6]](diffhunk://#diff-2ef33a1041c9f4a0bc1b9373cf036839f6d34c14ace1e5ab0a8f47847c2c65e3R237)

**World map zoom and navigation improvements:**

* Updated `WorldMapEditor` to respect the new Ctrl-only zoom preference, dynamically checking the setting at event time so changes take effect immediately.
* Changed the zoom slider to use a logarithmic scale for more natural zooming, and expanded the available zoom range. The minimum and maximum zoom values are now 1% to 500%. [[1]](diffhunk://#diff-6c07b4f495ab6e832e0d004eb7f5b9c372aead12346e58e680811004b90c42bdR49-R54) [[2]](diffhunk://#diff-6c07b4f495ab6e832e0d004eb7f5b9c372aead12346e58e680811004b90c42bdL115-R121) [[3]](diffhunk://#diff-6c07b4f495ab6e832e0d004eb7f5b9c372aead12346e58e680811004b90c42bdR152-R177) [[4]](diffhunk://#diff-6c07b4f495ab6e832e0d004eb7f5b9c372aead12346e58e680811004b90c42bdL157-R189) [[5]](diffhunk://#diff-6c07b4f495ab6e832e0d004eb7f5b9c372aead12346e58e680811004b90c42bdL343-R400) [[6]](diffhunk://#diff-074e190b788476dd58b87af00b0274e8a34f3ff7e11fd3d05e360331edc3192dL25-R26)

**Miscellaneous:**

* Minor code cleanups, such as removing the unnecessary `modified = false;` line in `TMXMapEditor`.
* Imports and small refactorings for clarity and maintainability.

These changes together provide a smoother, more customizable, and more efficient world map editing experience.