### PR TITLE
Preferences setting for enum values in comboboxes

### DIFF
--- a/src/com/gpl/rpg/atcontentstudio/model/WorkspaceSettings.java
+++ b/src/com/gpl/rpg/atcontentstudio/model/WorkspaceSettings.java
@@ -35,6 +35,9 @@ public class WorkspaceSettings {
     public static String DEFAULT_IMG_EDITOR_COMMAND = "gimp";
     public Setting<String> imageEditorCommand = new PrimitiveSetting<String>("imageEditorCommand", DEFAULT_IMG_EDITOR_COMMAND);
 
+    public static Boolean DEFAULT_USE_ENUM_VALUES_IN_COMBOBOXES = false;
+    public Setting<Boolean> useEnumValuesInComboboxes = new PrimitiveSetting<Boolean>("useEnumValuesInComboboxes", DEFAULT_USE_ENUM_VALUES_IN_COMBOBOXES);
+
     public static String[] LANGUAGE_LIST = new String[]{null, "de", "ru", "pl", "fr", "it", "es", "nl", "uk", "ca", "sv", "pt", "pt_BR", "zh_Hant", "zh_Hans", "ja", "cs", "tr", "ko", "hu", "sl", "bg", "id", "fi", "th", "gl", "ms", "pa", "az", "nb"};
     public Setting<String> translatorLanguage = new NullDefaultPrimitiveSetting<String>("translatorLanguage");
     public static Boolean DEFAULT_ALLOW_INTERNET = true;
@@ -53,6 +56,7 @@ public class WorkspaceSettings {
         settings.add(useSystemDefaultImageViewer);
         settings.add(useSystemDefaultImageEditor);
         settings.add(imageEditorCommand);
+        settings.add(useEnumValuesInComboboxes);
         settings.add(translatorLanguage);
         settings.add(useInternet);
         settings.add(checkUpdates);

--- a/src/com/gpl/rpg/atcontentstudio/model/WorkspaceSettings.java
+++ b/src/com/gpl/rpg/atcontentstudio/model/WorkspaceSettings.java
@@ -35,8 +35,8 @@ public class WorkspaceSettings {
     public static String DEFAULT_IMG_EDITOR_COMMAND = "gimp";
     public Setting<String> imageEditorCommand = new PrimitiveSetting<String>("imageEditorCommand", DEFAULT_IMG_EDITOR_COMMAND);
 
-    public static Boolean DEFAULT_USE_ENUM_VALUES_IN_COMBOBOXES = false;
-    public Setting<Boolean> useEnumValuesInComboboxes = new PrimitiveSetting<Boolean>("useEnumValuesInComboboxes", DEFAULT_USE_ENUM_VALUES_IN_COMBOBOXES);
+    public static Boolean DEFAULT_SHOW_ENUM_NAMES_IN_COMBOBOXES = false;
+    public Setting<Boolean> showEnumNamesInComboboxes = new PrimitiveSetting<Boolean>("showEnumNamesInComboboxes", DEFAULT_SHOW_ENUM_NAMES_IN_COMBOBOXES);
 
     public static String[] LANGUAGE_LIST = new String[]{null, "de", "ru", "pl", "fr", "it", "es", "nl", "uk", "ca", "sv", "pt", "pt_BR", "zh_Hant", "zh_Hans", "ja", "cs", "tr", "ko", "hu", "sl", "bg", "id", "fi", "th", "gl", "ms", "pa", "az", "nb"};
     public Setting<String> translatorLanguage = new NullDefaultPrimitiveSetting<String>("translatorLanguage");
@@ -56,7 +56,7 @@ public class WorkspaceSettings {
         settings.add(useSystemDefaultImageViewer);
         settings.add(useSystemDefaultImageEditor);
         settings.add(imageEditorCommand);
-        settings.add(useEnumValuesInComboboxes);
+        settings.add(showEnumNamesInComboboxes);
         settings.add(translatorLanguage);
         settings.add(useInternet);
         settings.add(checkUpdates);

--- a/src/com/gpl/rpg/atcontentstudio/model/gamedata/Requirement.java
+++ b/src/com/gpl/rpg/atcontentstudio/model/gamedata/Requirement.java
@@ -45,7 +45,7 @@ public class Requirement extends JSONElement {
     public GameDataElement required_obj = null;
 
     public enum RequirementType {
-        questProgress("Quest stage has been achieved"),
+        questProgress("Quest max stage ever achieved"),
         questLatestProgress("Quest is now at stage"),
         inventoryRemove("Hero has item in inventory (and remove it)"),
         inventoryKeep("Hero has item in inventory"),

--- a/src/com/gpl/rpg/atcontentstudio/ui/Editor.java
+++ b/src/com/gpl/rpg/atcontentstudio/ui/Editor.java
@@ -92,23 +92,23 @@ public abstract class Editor extends JPanel implements ProjectElementListener {
         }
     }
 
-    public static boolean useEnumValuesInComboboxes() {
+    public static boolean showEnumNamesInComboboxes() {
         return Workspace.activeWorkspace != null
                 && Workspace.activeWorkspace.settings != null
-                && Boolean.TRUE.equals(Workspace.activeWorkspace.settings.useEnumValuesInComboboxes.getCurrentValue());
+                && Boolean.TRUE.equals(Workspace.activeWorkspace.settings.showEnumNamesInComboboxes.getCurrentValue());
     }
 
     /**
-     * Returns a function that generates labels for enum values based on the current workspace settings.
-     * If the setting to use enum values in comboboxes is enabled, the label will include both the enum name and its description.
+     * Returns a function that generates labels for enum names based on the current workspace settings.
+     * If the setting to show enum names in comboboxes is enabled, the label will include both the enum name and its description.
      * Otherwise, it will only use the description.
      *
      * @param <E> The type of the enum.
      * @param descriptionGetter A function that provides the description for each enum value.
-     * @return A function that generates labels for enum values.
+     * @return A function that generates labels for enum names.
      */
     public static <E extends Enum<E>> Function<E, String> getEnumLabelGetter(Function<E, String> descriptionGetter) {
-        if (useEnumValuesInComboboxes()) {
+        if (showEnumNamesInComboboxes()) {
             return e -> e == null ? null : e.name() + " - " + descriptionGetter.apply(e);
         } else {
             return descriptionGetter;

--- a/src/com/gpl/rpg/atcontentstudio/ui/Editor.java
+++ b/src/com/gpl/rpg/atcontentstudio/ui/Editor.java
@@ -92,6 +92,29 @@ public abstract class Editor extends JPanel implements ProjectElementListener {
         }
     }
 
+    public static boolean useEnumValuesInComboboxes() {
+        return Workspace.activeWorkspace != null
+                && Workspace.activeWorkspace.settings != null
+                && Boolean.TRUE.equals(Workspace.activeWorkspace.settings.useEnumValuesInComboboxes.getCurrentValue());
+    }
+
+    /**
+     * Returns a function that generates labels for enum values based on the current workspace settings.
+     * If the setting to use enum values in comboboxes is enabled, the label will include both the enum name and its description.
+     * Otherwise, it will only use the description.
+     *
+     * @param <E> The type of the enum.
+     * @param descriptionGetter A function that provides the description for each enum value.
+     * @return A function that generates labels for enum values.
+     */
+    public static <E extends Enum<E>> Function<E, String> getEnumLabelGetter(Function<E, String> descriptionGetter) {
+        if (useEnumValuesInComboboxes()) {
+            return e -> e == null ? null : e.name() + " - " + descriptionGetter.apply(e);
+        } else {
+            return descriptionGetter;
+        }
+    }
+
 
     public static JTextField addLabelField(JPanel pane, String label, String value) {
         return addTextField(pane, label, value, false, nullListener);

--- a/src/com/gpl/rpg/atcontentstudio/ui/WorkspaceSettingsEditor.java
+++ b/src/com/gpl/rpg/atcontentstudio/ui/WorkspaceSettingsEditor.java
@@ -19,6 +19,7 @@ public class WorkspaceSettingsEditor extends JDialog {
     JTextField mapEditorCommandField;
     // Checkbox for the world map Ctrl-only zoom preference.
     JCheckBox zoomWorldMapOnlyWithCtrlBox;
+    JCheckBox useEnumValuesInComboboxes;
 
     JRadioButton useSystemDefaultImageViewerButton, useSystemDefaultImageEditorButton, useCustomImageEditorButton;
     JTextField imageEditorCommandField;
@@ -200,6 +201,9 @@ public class WorkspaceSettingsEditor extends JDialog {
         zoomWorldMapOnlyWithCtrlBox = new JCheckBox("Use Ctrl+Wheel to zoom World Map");
         pane.add(zoomWorldMapOnlyWithCtrlBox, JideBoxLayout.FIX);
 
+        useEnumValuesInComboboxes = new JCheckBox("Use Enum Values in Requirement, Reward, and Skill Comboboxes");
+        pane.add(useEnumValuesInComboboxes, JideBoxLayout.FIX);
+
         return pane;
     }
 
@@ -209,6 +213,7 @@ public class WorkspaceSettingsEditor extends JDialog {
         useCustomMapEditorButton.setSelected(!settings.useSystemDefaultMapEditor.getCurrentValue());
         mapEditorCommandField.setText(settings.mapEditorCommand.getCurrentValue());
         zoomWorldMapOnlyWithCtrlBox.setSelected(settings.zoomWorldMapOnlyWithCtrl.getCurrentValue());
+        useEnumValuesInComboboxes.setSelected(settings.useEnumValuesInComboboxes.getCurrentValue());
         //Images
         useSystemDefaultImageViewerButton.setSelected(settings.useSystemDefaultImageViewer.getCurrentValue());
         useSystemDefaultImageEditorButton.setSelected(settings.useSystemDefaultImageEditor.getCurrentValue());
@@ -235,6 +240,7 @@ public class WorkspaceSettingsEditor extends JDialog {
         settings.useSystemDefaultMapEditor.setCurrentValue(useSystemDefaultMapEditorButton.isSelected());
         settings.mapEditorCommand.setCurrentValue(mapEditorCommandField.getText());
         settings.zoomWorldMapOnlyWithCtrl.setCurrentValue(zoomWorldMapOnlyWithCtrlBox.isSelected());
+        settings.useEnumValuesInComboboxes.setCurrentValue(useEnumValuesInComboboxes.isSelected());
         //Images
         settings.useSystemDefaultImageViewer.setCurrentValue(useSystemDefaultImageViewerButton.isSelected());
         settings.useSystemDefaultImageEditor.setCurrentValue(useSystemDefaultImageEditorButton.isSelected());

--- a/src/com/gpl/rpg/atcontentstudio/ui/WorkspaceSettingsEditor.java
+++ b/src/com/gpl/rpg/atcontentstudio/ui/WorkspaceSettingsEditor.java
@@ -19,7 +19,7 @@ public class WorkspaceSettingsEditor extends JDialog {
     JTextField mapEditorCommandField;
     // Checkbox for the world map Ctrl-only zoom preference.
     JCheckBox zoomWorldMapOnlyWithCtrlBox;
-    JCheckBox useEnumValuesInComboboxes;
+    JCheckBox showEnumNamesInComboboxes;
 
     JRadioButton useSystemDefaultImageViewerButton, useSystemDefaultImageEditorButton, useCustomImageEditorButton;
     JTextField imageEditorCommandField;
@@ -201,8 +201,8 @@ public class WorkspaceSettingsEditor extends JDialog {
         zoomWorldMapOnlyWithCtrlBox = new JCheckBox("Use Ctrl+Wheel to zoom World Map");
         pane.add(zoomWorldMapOnlyWithCtrlBox, JideBoxLayout.FIX);
 
-        useEnumValuesInComboboxes = new JCheckBox("Use Enum Values in Requirement, Reward, and Skill Comboboxes");
-        pane.add(useEnumValuesInComboboxes, JideBoxLayout.FIX);
+        showEnumNamesInComboboxes = new JCheckBox("Show Enum Names in Requirement, Reward, and Skill Comboboxes");
+        pane.add(showEnumNamesInComboboxes, JideBoxLayout.FIX);
 
         return pane;
     }
@@ -213,7 +213,7 @@ public class WorkspaceSettingsEditor extends JDialog {
         useCustomMapEditorButton.setSelected(!settings.useSystemDefaultMapEditor.getCurrentValue());
         mapEditorCommandField.setText(settings.mapEditorCommand.getCurrentValue());
         zoomWorldMapOnlyWithCtrlBox.setSelected(settings.zoomWorldMapOnlyWithCtrl.getCurrentValue());
-        useEnumValuesInComboboxes.setSelected(settings.useEnumValuesInComboboxes.getCurrentValue());
+        showEnumNamesInComboboxes.setSelected(settings.showEnumNamesInComboboxes.getCurrentValue());
         //Images
         useSystemDefaultImageViewerButton.setSelected(settings.useSystemDefaultImageViewer.getCurrentValue());
         useSystemDefaultImageEditorButton.setSelected(settings.useSystemDefaultImageEditor.getCurrentValue());
@@ -240,7 +240,7 @@ public class WorkspaceSettingsEditor extends JDialog {
         settings.useSystemDefaultMapEditor.setCurrentValue(useSystemDefaultMapEditorButton.isSelected());
         settings.mapEditorCommand.setCurrentValue(mapEditorCommandField.getText());
         settings.zoomWorldMapOnlyWithCtrl.setCurrentValue(zoomWorldMapOnlyWithCtrlBox.isSelected());
-        settings.useEnumValuesInComboboxes.setCurrentValue(useEnumValuesInComboboxes.isSelected());
+        settings.showEnumNamesInComboboxes.setCurrentValue(showEnumNamesInComboboxes.isSelected());
         //Images
         settings.useSystemDefaultImageViewer.setCurrentValue(useSystemDefaultImageViewerButton.isSelected());
         settings.useSystemDefaultImageEditor.setCurrentValue(useSystemDefaultImageEditorButton.isSelected());

--- a/src/com/gpl/rpg/atcontentstudio/ui/gamedataeditors/DialogueEditor.java
+++ b/src/com/gpl/rpg/atcontentstudio/ui/gamedataeditors/DialogueEditor.java
@@ -223,7 +223,7 @@ public class DialogueEditor extends JSONElementEditor {
                     Dialogue.Reward.RewardType.values(),
                     reward.type,
                     ((Dialogue) target).writable,
-                    Dialogue.Reward.RewardType::getDescription,
+                    getEnumLabelGetter(Dialogue.Reward.RewardType::getDescription),
                     listener
             );
             rewardsParamsPane = new JPanel();
@@ -422,7 +422,15 @@ public class DialogueEditor extends JSONElementEditor {
                     }
                     rewardMap = null;
                     rewardObjId = null;// addTextField(pane, "Skill ID: ", reward.reward_obj_id, writable, listener);
-                    rewardObjIdCombo = addEnumValueBoxWithDescriptions(pane, "Skill ID: ", Requirement.SkillID.values(), skillId, writable, Requirement.SkillID::getDescription, listener);
+                    rewardObjIdCombo = addEnumValueBoxWithDescriptions(
+                            pane,
+                            "Skill ID: ",
+                            Requirement.SkillID.values(),
+                            skillId,
+                            writable,
+                            getEnumLabelGetter(Requirement.SkillID::getDescription),
+                            listener
+                    );
                     rewardObj = null;
                     rewardValue = null;
                     break;
@@ -468,7 +476,7 @@ public class DialogueEditor extends JSONElementEditor {
                 Requirement.RequirementType.values(),
                 requirement == null ? null : requirement.type,
                 writable,
-                Requirement.RequirementType::getDescription,
+                getEnumLabelGetter(Requirement.RequirementType::getDescription),
                 listener
         );
 
@@ -772,7 +780,15 @@ public class DialogueEditor extends JSONElementEditor {
             removeElementListener(requirementObj);
         }
 
-        requirementTypeCombo = addEnumValueBoxWithDescriptions(pane, "Requirement type: ", Requirement.RequirementType.values(), requirement == null ? null : requirement.type, writable, Requirement.RequirementType::getDescription, listener);
+        requirementTypeCombo = addEnumValueBoxWithDescriptions(
+                pane,
+                "Requirement type: ",
+                Requirement.RequirementType.values(),
+                requirement == null ? null : requirement.type,
+                writable,
+                getEnumLabelGetter(Requirement.RequirementType::getDescription),
+                listener
+        );
         requirementParamsPane = new JPanel();
         requirementParamsPane.setLayout(new JideBoxLayout(requirementParamsPane, JideBoxLayout.PAGE_AXIS));
         updateRequirementParamsEditorPane(requirementParamsPane, requirement, listener);
@@ -834,7 +850,15 @@ public class DialogueEditor extends JSONElementEditor {
                     } catch (IllegalArgumentException e) {
                     }
                     requirementObj = null;
-                    requirementSkill = addEnumValueBoxWithDescriptions(pane, "Skill ID:", Requirement.SkillID.values(), skillId, writable, Requirement.SkillID::getDescription, listener);
+                    requirementSkill = addEnumValueBoxWithDescriptions(
+                            pane,
+                            "Skill ID:",
+                            Requirement.SkillID.values(),
+                            skillId,
+                            writable,
+                            getEnumLabelGetter(Requirement.SkillID::getDescription),
+                            listener
+                    );
                     requirementObjId = null;//addTextField(pane, "Skill ID:", requirement.required_obj_id, writable, listener);
                     requirementValue = addIntegerField(pane, "Level: ", requirement.required_value, false, writable, listener);
                     break;
@@ -880,7 +904,15 @@ public class DialogueEditor extends JSONElementEditor {
                     } catch (IllegalArgumentException e) {
                     }
                     requirementObj = null;
-                    requirementSkill = addEnumValueBoxWithDescriptions(pane, "Skill ID:", Requirement.SkillID.values(), skillId, writable, Requirement.SkillID::getDescription, listener);
+                    requirementSkill = addEnumValueBoxWithDescriptions(
+                            pane,
+                            "Skill ID:",
+                            Requirement.SkillID.values(),
+                            skillId,
+                            writable,
+                            getEnumLabelGetter(Requirement.SkillID::getDescription),
+                            listener
+                    );
                     requirementObjId = null;//addTextField(pane, "Skill ID:", requirement.required_obj_id, writable, listener);
                     requirementValue = addIntegerField(pane, "Level up: ", requirement.required_value, false, writable, listener);
                     break;

--- a/src/com/gpl/rpg/atcontentstudio/ui/gamedataeditors/NPCEditor.java
+++ b/src/com/gpl/rpg/atcontentstudio/ui/gamedataeditors/NPCEditor.java
@@ -133,7 +133,15 @@ public class NPCEditor extends JSONElementEditor {
         experienceField = addIntegerField(pane, "Experience reward: ", npc.getMonsterExperience(), false, false, listener);
         dialogueBox = addDialogueBox(pane, npc.getProject(), "Initial phrase: ", npc.dialogue, npc.writable, listener);
         droplistBox = addDroplistBox(pane, npc.getProject(), "Droplist / Shop inventory: ", npc.droplist, npc.writable, listener);
-        monsterClassBox = addEnumValueBoxWithDescriptions(pane, "Monster class: ", NPC.MonsterClass.values(), npc.monster_class, npc.writable, NPC.MonsterClass::getDescription, listener);
+        monsterClassBox = addEnumValueBoxWithDescriptions(
+                pane,
+                "Monster class: ",
+                NPC.MonsterClass.values(),
+                npc.monster_class,
+                npc.writable,
+                NPC.MonsterClass::getDescription,
+                listener
+        );
         uniqueBox = addIntegerBasedCheckBox(pane, "Unique", npc.unique, npc.writable, listener);
         moveTypeBox = addEnumValueBox(pane, "Movement type: ", NPC.MovementType.values(), npc.movement_type, npc.writable, listener);
         combatTraitPane = new CollapsiblePanel("Combat traits: ");

--- a/src/com/gpl/rpg/atcontentstudio/ui/map/TMXMapEditor.java
+++ b/src/com/gpl/rpg/atcontentstudio/ui/map/TMXMapEditor.java
@@ -618,7 +618,7 @@ public class TMXMapEditor extends Editor implements TMXMap.MapChangedOnDiskListe
                             Requirement.SkillID.values(),
                             skillId,
                             writable,
-                            Requirement.SkillID::getDescription,
+                            getEnumLabelGetter(Requirement.SkillID::getDescription),
                             listener
                     );
                     requirementObjId = null;//addTextField(pane, "Skill ID:", requirement.required_obj_id, writable, listener);

--- a/src/com/gpl/rpg/atcontentstudio/ui/map/TMXMapEditor.java
+++ b/src/com/gpl/rpg/atcontentstudio/ui/map/TMXMapEditor.java
@@ -386,7 +386,15 @@ public class TMXMapEditor extends Editor implements TMXMap.MapChangedOnDiskListe
         } else if (selected instanceof KeyArea) {
             areaField = addTextField(pane, "Area ID: ", ((KeyArea) selected).name, ((TMXMap) target).writable, listener);
             dialogueBox = addDialogueBox(pane, ((TMXMap) target).getProject(), "Message when locked: ", ((KeyArea) selected).dialogue, ((TMXMap) target).writable, listener);
-            requirementTypeCombo = addEnumValueBoxWithDescriptions(pane, "Requirement type: ", Requirement.RequirementType.values(), ((KeyArea) selected).requirement.type, ((TMXMap) target).writable, Requirement.RequirementType::getDescription, listener);
+            requirementTypeCombo = addEnumValueBoxWithDescriptions(
+                    pane,
+                    "Requirement type: ",
+                    Requirement.RequirementType.values(),
+                    ((KeyArea) selected).requirement.type,
+                    ((TMXMap) target).writable,
+                    getEnumLabelGetter(Requirement.RequirementType::getDescription),
+                    listener
+            );
             requirementParamsPane = new JPanel();
             requirementParamsPane.setLayout(new JideBoxLayout(requirementParamsPane, JideBoxLayout.PAGE_AXIS, 6));
             pane.add(requirementParamsPane, JideBoxLayout.FIX);
@@ -450,7 +458,15 @@ public class TMXMapEditor extends Editor implements TMXMap.MapChangedOnDiskListe
             // Area ID field
             areaField = addTextField(pane, "Area ID: ", ((ReplaceArea) selected).name, ((TMXMap) target).writable, listener);
             // Requirement Type combobox
-            requirementTypeCombo = addEnumValueBoxWithDescriptions(pane, "Requirement type: ", Requirement.RequirementType.values(), ((ReplaceArea) selected).requirement.type, ((TMXMap) target).writable, Requirement.RequirementType::getDescription, listener);
+            requirementTypeCombo = addEnumValueBoxWithDescriptions(
+                    pane,
+                    "Requirement type: ",
+                    Requirement.RequirementType.values(),
+                    ((ReplaceArea) selected).requirement.type,
+                    ((TMXMap) target).writable,
+                    getEnumLabelGetter(Requirement.RequirementType::getDescription),
+                    listener
+            );
             // Set pane for variable requirement parameters (populated by updateRequirementParamsPane())
             requirementParamsPane = new JPanel();
             requirementParamsPane.setLayout(new JideBoxLayout(requirementParamsPane, JideBoxLayout.PAGE_AXIS, 6));
@@ -596,7 +612,15 @@ public class TMXMapEditor extends Editor implements TMXMap.MapChangedOnDiskListe
                         skillId = requirement.required_obj_id == null ? null : Requirement.SkillID.valueOf(requirement.required_obj_id);
                     } catch (IllegalArgumentException e) {
                     }
-                    requirementObj = addEnumValueBoxWithDescriptions(pane, "Skill ID:", Requirement.SkillID.values(), skillId, writable, Requirement.SkillID::getDescription, listener);
+                    requirementObj = addEnumValueBoxWithDescriptions(
+                            pane,
+                            "Skill ID:",
+                            Requirement.SkillID.values(),
+                            skillId,
+                            writable,
+                            Requirement.SkillID::getDescription,
+                            listener
+                    );
                     requirementObjId = null;//addTextField(pane, "Skill ID:", requirement.required_obj_id, writable, listener);
                     requirementValue = addIntegerField(pane, "Level: ", requirement.required_value, false, writable, listener);
                     break;
@@ -641,7 +665,15 @@ public class TMXMapEditor extends Editor implements TMXMap.MapChangedOnDiskListe
                         skillId = requirement.required_obj_id == null ? null : Requirement.SkillID.valueOf(requirement.required_obj_id);
                     } catch (IllegalArgumentException e) {
                     }
-                    requirementObj = addEnumValueBoxWithDescriptions(pane, "Skill ID:", Requirement.SkillID.values(), skillId, writable, Requirement.SkillID::getDescription, listener);
+                    requirementObj = addEnumValueBoxWithDescriptions(
+                            pane,
+                            "Skill ID:",
+                            Requirement.SkillID.values(),
+                            skillId,
+                            writable,
+                            getEnumLabelGetter(Requirement.SkillID::getDescription),
+                            listener
+                    );
                     requirementObjId = null;//addTextField(pane, "Skill ID:", requirement.required_obj_id, writable, listener);
                     requirementValue = addIntegerField(pane, "Level: ", requirement.required_value, false, writable, listener);
                     break;


### PR DESCRIPTION
This pull request introduces a new workspace setting that allows users to choose whether enums in Requirement, Reward, and Skill comboboxes are displayed (and alphabetized) with their raw names first or just their descriptions. There is also a minor update to the description of a requirement type.

**Workspace Settings and UI Integration:**

* Added the `useEnumValuesInComboboxes` setting to `WorkspaceSettings`, including default value, persistence, and UI control in `WorkspaceSettingsEditor`, so users can toggle whether enum comboboxes show enum names, descriptions, or both. [[1]](diffhunk://#diff-d4dfa3b3bf00daf452fcbad8a1f867418cf27252b4a2bde3134b95d46936fd37R38-R40) [[2]](diffhunk://#diff-d4dfa3b3bf00daf452fcbad8a1f867418cf27252b4a2bde3134b95d46936fd37R59) [[3]](diffhunk://#diff-2ef33a1041c9f4a0bc1b9373cf036839f6d34c14ace1e5ab0a8f47847c2c65e3R22) [[4]](diffhunk://#diff-2ef33a1041c9f4a0bc1b9373cf036839f6d34c14ace1e5ab0a8f47847c2c65e3R204-R206) [[5]](diffhunk://#diff-2ef33a1041c9f4a0bc1b9373cf036839f6d34c14ace1e5ab0a8f47847c2c65e3R216) [[6]](diffhunk://#diff-2ef33a1041c9f4a0bc1b9373cf036839f6d34c14ace1e5ab0a8f47847c2c65e3R243)
* Implemented the static helper `getEnumLabelGetter` in `Editor` to centralize label generation for enum comboboxes based on the workspace setting, and updated all relevant comboboxes in editors (Dialogue, NPC, Map) to use this helper. [[1]](diffhunk://#diff-23045c9318a22ca46d723ae2d1e9a2fabd4c764cf900b9715854f7d5fe69eb7bR95-R117) [[2]](diffhunk://#diff-f9b69b6f3172737b4d257f333a57364c927e2091be3b173e471d9ba1de46e346L226-R226) [[3]](diffhunk://#diff-f9b69b6f3172737b4d257f333a57364c927e2091be3b173e471d9ba1de46e346L425-R433) [[4]](diffhunk://#diff-f9b69b6f3172737b4d257f333a57364c927e2091be3b173e471d9ba1de46e346L471-R479) [[5]](diffhunk://#diff-f9b69b6f3172737b4d257f333a57364c927e2091be3b173e471d9ba1de46e346L775-R791) [[6]](diffhunk://#diff-f9b69b6f3172737b4d257f333a57364c927e2091be3b173e471d9ba1de46e346L837-R861) [[7]](diffhunk://#diff-f9b69b6f3172737b4d257f333a57364c927e2091be3b173e471d9ba1de46e346L883-R915) [[8]](diffhunk://#diff-2eaa634d879187505d737c527fefaebf252c2e078aaa232a5a25605447cb7dd7L136-R144) [[9]](diffhunk://#diff-d5d6f0954c84fc7c838c1fbb44a920b92eaa61b63c1a6a880e851721223496eaL389-R397) [[10]](diffhunk://#diff-d5d6f0954c84fc7c838c1fbb44a920b92eaa61b63c1a6a880e851721223496eaL453-R469) [[11]](diffhunk://#diff-d5d6f0954c84fc7c838c1fbb44a920b92eaa61b63c1a6a880e851721223496eaL599-R623) [[12]](diffhunk://#diff-d5d6f0954c84fc7c838c1fbb44a920b92eaa61b63c1a6a880e851721223496eaL644-R676)

**Enum Description Update:**

* Updated the description for `RequirementType.questProgress` to clarify that it refers to the "max stage ever achieved" rather than simply "stage has been achieved."