### PR TITLE
Merge next_release for 0.7.2beta2

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ Or run the built jar directly:
 java -jar build/libs/ATContentStudio-<version>-all.jar
 ```
 
+On Windows, add `--show-console` to allocate and attach a console window.
+
 ## Build
 
 On Linux/macOS:

--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ repositories {
 // Local jars are checked into lib/ and used as implementation/test dependencies.
 dependencies {
     implementation fileTree(dir: 'lib', include: ['*.jar'], exclude: ['junit-*.jar', '*-sources.jar'])
+    implementation 'net.java.dev.jna:jna:5.15.0' // Needed for Windows console support
 
     testImplementation files('lib/junit-4.10.jar')
 }

--- a/src/com/gpl/rpg/atcontentstudio/ATContentStudio.java
+++ b/src/com/gpl/rpg/atcontentstudio/ATContentStudio.java
@@ -621,7 +621,7 @@ public class ATContentStudio {
                     "Notes:",
                     "  - If <target> ends with .zip, ATCS exports a zip package.",
                     "  - Otherwise, <target> must be an existing game-source directory.",
-                    "  - --show-console allocates and attaches a Windows console window.",
+                    "  - --show-console allocates and attaches a console window (Windows platform only).",
                     "  - --skip-lock-check bypasses single-instance workspace locking.",
                     "  - --ignore-config ignores saved global config and behaves like a fresh install for this run.",
             }

--- a/src/com/gpl/rpg/atcontentstudio/ATContentStudio.java
+++ b/src/com/gpl/rpg/atcontentstudio/ATContentStudio.java
@@ -20,6 +20,8 @@ import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.io.BufferedReader;
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.PrintStream;
@@ -48,6 +50,7 @@ public class ATContentStudio {
     private static final String QUIET_ARGUMENT = "--quiet";
     private static final String SKIP_LOCK_CHECK_ARGUMENT = "--skip-lock-check";
     private static final String IGNORE_EXISTING_CONFIG_ARGUMENT = "--ignore-config";
+    private static final String SHOW_CONSOLE_ARGUMENT = "--show-console";
     private static final String RESTART_HELPER_ARGUMENT = "--restart-helper";
     private static final String WAIT_FOR_PID_ARGUMENT = "--wait-for-pid";
     private static final String HELP_ARGUMENT = "--help";
@@ -105,6 +108,16 @@ public class ATContentStudio {
             printCommandLineUsage(System.out);
             System.exit(0);
             return;
+        }
+
+        if (startupArguments.showConsole) {
+            if (isWindows()) {
+                if (!enableWindowsConsole()) {
+                    System.err.println("Failed to allocate a console window.");
+                }
+            } else {
+                System.err.println("--show-console is only supported on Windows.");
+            }
         }
 
         if (startupArguments.isHeadlessExportRequested()) {
@@ -558,20 +571,57 @@ public class ATContentStudio {
         ConfigCache.setLatestWorkspace(workspaceRoot);
     }
 
+    private static boolean enableWindowsConsole() {
+        if (WindowsConsole.KERNEL32.AttachConsole(WindowsConsole.ATTACH_PARENT_PROCESS) || WindowsConsole.KERNEL32.AllocConsole()) {
+            redirectStandardStreamsToConsole();
+            return true;
+        }
+        return false;
+    }
+
+    private static boolean isWindows() {
+        return System.getProperty("os.name", "").toLowerCase(Locale.ROOT).contains("win");
+    }
+
+    private static void redirectStandardStreamsToConsole() {
+        try {
+            PrintStream consoleOut = new PrintStream(new FileOutputStream("CONOUT$"), true);
+            System.setOut(consoleOut);
+            System.setErr(consoleOut);
+            System.setIn(new FileInputStream("CONIN$"));
+        } catch (IOException e) {
+            throw new IllegalStateException("Console was allocated but standard streams could not be redirected.", e);
+        }
+    }
+
+    private static final class WindowsConsole {
+        private static final int ATTACH_PARENT_PROCESS = -1;
+        private static final Kernel32 KERNEL32 = com.sun.jna.Native.load("kernel32", Kernel32.class);
+
+        private WindowsConsole() {
+        }
+
+        private interface Kernel32 extends com.sun.jna.Library {
+            boolean AttachConsole(int dwProcessId);
+            boolean AllocConsole();
+        }
+    }
+
     @Command(
             name = "ATContentStudio",
             sortOptions = false,
             customSynopsis = {
                     "  GUI mode:",
-                    "    ATContentStudio [--help] [--workspace <workspace>] [--export-target <path>] [--skip-lock-check] [--ignore-config]",
+                    "    ATContentStudio [--help] [--show-console] [--workspace <workspace>] [--export-target <path>] [--skip-lock-check] [--ignore-config]",
                     "  Headless export mode:",
-                    "    ATContentStudio [--help] --workspace <workspace> --project <project-name> --export-target <target> [-q|--quiet] [--skip-lock-check] [--ignore-config]"
+                    "    ATContentStudio [--help] [--show-console] --workspace <workspace> --project <project-name> --export-target <target> [-q|--quiet] [--skip-lock-check] [--ignore-config]"
             },
             description = "Launches Andor's Trail Content Studio in GUI mode or headless export mode.",
             footer = {
                     "Notes:",
                     "  - If <target> ends with .zip, ATCS exports a zip package.",
                     "  - Otherwise, <target> must be an existing game-source directory.",
+                    "  - --show-console allocates and attaches a Windows console window.",
                     "  - --skip-lock-check bypasses single-instance workspace locking.",
                     "  - --ignore-config ignores saved global config and behaves like a fresh install for this run.",
             }
@@ -594,6 +644,9 @@ public class ATContentStudio {
 
         @Option(names = IGNORE_EXISTING_CONFIG_ARGUMENT, description = "Ignores saved global config and behaves like a fresh install for this run.")
         private boolean ignoreExistingConfig;
+
+        @Option(names = SHOW_CONSOLE_ARGUMENT, description = "Allocates and attaches a Windows console window.")
+        private boolean showConsole;
 
         @Option(names = RESTART_HELPER_ARGUMENT, hidden = true)
         private boolean restartHelper;

--- a/src/com/gpl/rpg/atcontentstudio/model/WorkspaceSettings.java
+++ b/src/com/gpl/rpg/atcontentstudio/model/WorkspaceSettings.java
@@ -24,6 +24,9 @@ public class WorkspaceSettings {
     public Setting<Boolean> useSystemDefaultMapEditor = new PrimitiveSetting<Boolean>("useSystemDefaultMapEditor", DEFAULT_USE_SYS_MAP_EDITOR);
     public static String DEFAULT_MAP_EDITOR_COMMAND = "tiled";
     public Setting<String> mapEditorCommand = new PrimitiveSetting<String>("mapEditorCommand", DEFAULT_MAP_EDITOR_COMMAND);
+    // When enabled, world map zoom only reacts to Ctrl + mouse wheel.
+    public static Boolean DEFAULT_ZOOM_WORLD_MAP_ONLY_WITH_CTRL = false;
+    public Setting<Boolean> zoomWorldMapOnlyWithCtrl = new PrimitiveSetting<Boolean>("zoomWorldMapOnlyWithCtrl", DEFAULT_ZOOM_WORLD_MAP_ONLY_WITH_CTRL);
 
     public static Boolean DEFAULT_USE_SYS_IMG_VIEWER = true;
     public Setting<Boolean> useSystemDefaultImageViewer = new PrimitiveSetting<Boolean>("useSystemDefaultImageViewer", DEFAULT_USE_SYS_IMG_VIEWER);
@@ -46,6 +49,7 @@ public class WorkspaceSettings {
         this.parent = parent;
         settings.add(useSystemDefaultMapEditor);
         settings.add(mapEditorCommand);
+        settings.add(zoomWorldMapOnlyWithCtrl);
         settings.add(useSystemDefaultImageViewer);
         settings.add(useSystemDefaultImageEditor);
         settings.add(imageEditorCommand);

--- a/src/com/gpl/rpg/atcontentstudio/model/WorkspaceSettings.java
+++ b/src/com/gpl/rpg/atcontentstudio/model/WorkspaceSettings.java
@@ -35,6 +35,9 @@ public class WorkspaceSettings {
     public static String DEFAULT_IMG_EDITOR_COMMAND = "gimp";
     public Setting<String> imageEditorCommand = new PrimitiveSetting<String>("imageEditorCommand", DEFAULT_IMG_EDITOR_COMMAND);
 
+    public static Boolean DEFAULT_USE_ENUM_VALUES_IN_COMBOBOXES = false;
+    public Setting<Boolean> useEnumValuesInComboboxes = new PrimitiveSetting<Boolean>("useEnumValuesInComboboxes", DEFAULT_USE_ENUM_VALUES_IN_COMBOBOXES);
+
     public static String[] LANGUAGE_LIST = new String[]{null, "de", "ru", "pl", "fr", "it", "es", "nl", "uk", "ca", "sv", "pt", "pt_BR", "zh_Hant", "zh_Hans", "ja", "cs", "tr", "ko", "hu", "sl", "bg", "id", "fi", "th", "gl", "ms", "pa", "az", "nb"};
     public Setting<String> translatorLanguage = new NullDefaultPrimitiveSetting<String>("translatorLanguage");
     public static Boolean DEFAULT_ALLOW_INTERNET = true;
@@ -53,6 +56,7 @@ public class WorkspaceSettings {
         settings.add(useSystemDefaultImageViewer);
         settings.add(useSystemDefaultImageEditor);
         settings.add(imageEditorCommand);
+        settings.add(useEnumValuesInComboboxes);
         settings.add(translatorLanguage);
         settings.add(useInternet);
         settings.add(checkUpdates);

--- a/src/com/gpl/rpg/atcontentstudio/model/WorkspaceSettings.java
+++ b/src/com/gpl/rpg/atcontentstudio/model/WorkspaceSettings.java
@@ -35,8 +35,8 @@ public class WorkspaceSettings {
     public static String DEFAULT_IMG_EDITOR_COMMAND = "gimp";
     public Setting<String> imageEditorCommand = new PrimitiveSetting<String>("imageEditorCommand", DEFAULT_IMG_EDITOR_COMMAND);
 
-    public static Boolean DEFAULT_USE_ENUM_VALUES_IN_COMBOBOXES = false;
-    public Setting<Boolean> useEnumValuesInComboboxes = new PrimitiveSetting<Boolean>("useEnumValuesInComboboxes", DEFAULT_USE_ENUM_VALUES_IN_COMBOBOXES);
+    public static Boolean DEFAULT_SHOW_ENUM_NAMES_IN_COMBOBOXES = false;
+    public Setting<Boolean> showEnumNamesInComboboxes = new PrimitiveSetting<Boolean>("showEnumNamesInComboboxes", DEFAULT_SHOW_ENUM_NAMES_IN_COMBOBOXES);
 
     public static String[] LANGUAGE_LIST = new String[]{null, "de", "ru", "pl", "fr", "it", "es", "nl", "uk", "ca", "sv", "pt", "pt_BR", "zh_Hant", "zh_Hans", "ja", "cs", "tr", "ko", "hu", "sl", "bg", "id", "fi", "th", "gl", "ms", "pa", "az", "nb"};
     public Setting<String> translatorLanguage = new NullDefaultPrimitiveSetting<String>("translatorLanguage");
@@ -56,7 +56,7 @@ public class WorkspaceSettings {
         settings.add(useSystemDefaultImageViewer);
         settings.add(useSystemDefaultImageEditor);
         settings.add(imageEditorCommand);
-        settings.add(useEnumValuesInComboboxes);
+        settings.add(showEnumNamesInComboboxes);
         settings.add(translatorLanguage);
         settings.add(useInternet);
         settings.add(checkUpdates);

--- a/src/com/gpl/rpg/atcontentstudio/model/gamedata/Requirement.java
+++ b/src/com/gpl/rpg/atcontentstudio/model/gamedata/Requirement.java
@@ -45,7 +45,7 @@ public class Requirement extends JSONElement {
     public GameDataElement required_obj = null;
 
     public enum RequirementType {
-        questProgress("Quest stage has been achieved"),
+        questProgress("Quest max stage ever achieved"),
         questLatestProgress("Quest is now at stage"),
         inventoryRemove("Hero has item in inventory (and remove it)"),
         inventoryKeep("Hero has item in inventory"),

--- a/src/com/gpl/rpg/atcontentstudio/model/maps/TMXMap.java
+++ b/src/com/gpl/rpg/atcontentstudio/model/maps/TMXMap.java
@@ -54,6 +54,8 @@ public class TMXMap extends GameDataElement {
 
     public boolean changedOnDisk = false;
     public int dismissNextChangeNotif = 0;
+    // Bumps whenever the rendered TMX content changes so view caches can invalidate lazily.
+    private long renderGeneration = 0;
 
     public TMXMap(TMXMapSet parent, File f) {
         this.parent = parent;
@@ -177,6 +179,7 @@ public class TMXMap extends GameDataElement {
 
     @Override
     public void childrenChanged(List<ProjectTreeNode> path) {
+        renderGeneration++;
         path.add(0, this);
         parent.childrenChanged(path);
     }
@@ -339,6 +342,7 @@ public class TMXMap extends GameDataElement {
 
     public void addLayer(tiled.core.MapLayer layer) {
         tmxMap.addLayer(layer);
+        renderGeneration++;
         if (layer instanceof tiled.core.ObjectGroup) {
             groups.add(new MapObjectGroup((tiled.core.ObjectGroup) layer, this));
         }
@@ -346,6 +350,7 @@ public class TMXMap extends GameDataElement {
 
     public void removeLayer(tiled.core.MapLayer layer) {
         tmxMap.removeLayer(tmxMap.getLayerIndex(layer));
+        renderGeneration++;
         if (layer instanceof tiled.core.ObjectGroup) {
             MapObjectGroup toRemove = null;
             for (MapObjectGroup group : groups) {
@@ -405,6 +410,7 @@ public class TMXMap extends GameDataElement {
 
     public void reload() {
         tmxMap = null;
+        renderGeneration++;
         for (Spritesheet s : usedSpritesheets) {
             s.elementChanged(this, null);
         }
@@ -447,6 +453,15 @@ public class TMXMap extends GameDataElement {
         for (MapChangedOnDiskListener l : listeners) {
             l.mapReloaded();
         }
+    }
+
+    /**
+     * Returns the current render generation for cache invalidation.
+     *
+     * @return monotonically increasing render generation
+     */
+    public long getRenderGeneration() {
+        return renderGeneration;
     }
 
     public void mapChangedOnDisk() {

--- a/src/com/gpl/rpg/atcontentstudio/ui/Editor.java
+++ b/src/com/gpl/rpg/atcontentstudio/ui/Editor.java
@@ -787,7 +787,7 @@ public abstract class Editor extends JPanel implements ProjectElementListener {
         gdePane.setLayout(new JideBoxLayout(gdePane, JideBoxLayout.LINE_AXIS, 6));
         JLabel gdeLabel = new JLabel(label);
         gdePane.add(gdeLabel, JideBoxLayout.FIX);
-        final SortedGDEComboModel<? extends GameDataElement> wrappedModel = new SortedGDEComboModel<>(comboModel);
+        final SortedGDEComboModel<? extends GameDataElement> wrappedModel = new SortedGDEComboModel<>(comboModel, createGDEComboSections());
         final MyComboBox gdeBox = new MyComboBox(dataClass, wrappedModel);
         gdeBox.setRenderer(new GDERenderer(false, writable));
         new ComboBoxSearchable(gdeBox) {
@@ -994,7 +994,7 @@ public abstract class Editor extends JPanel implements ProjectElementListener {
         private final List<Row<E>> rows = new ArrayList<Row<E>>();
 
         /**
-         * Creates the default two-section view: Project, and Game Source.
+         * Creates a single-section view with no header row.
          */
         public SortedGDEComboModel(GDEComboModel<E> source) {
             this(source, defaultSections());
@@ -1229,32 +1229,9 @@ public abstract class Editor extends JPanel implements ProjectElementListener {
         }
 
         /**
-         * Returns the section definitions used by the default model.
-         */
-        private static <E extends GameDataElement> List<Section<E>> defaultSections() {
-            Comparator<E> comparator = buildComparator();
-            List<Section<E>> result = new ArrayList<Section<E>>();
-            result.add(new Section<E>(PROJECT_HEADER, e -> e.getDataType() == GameSource.Type.altered  || e.getDataType() == GameSource.Type.created, comparator, e -> {
-                String desc = normalizeDesc(e.getDesc());
-                desc = switch (e.getDataType()) {
-                    case created -> desc + " (C)";
-                    case altered -> desc + " (A)";
-                    default -> desc;
-                };
-                return desc;
-            }));
-            //result.add(new Section<E>(GAME_SOURCE_HEADER, e -> e.getDataType() == GameSource.Type.source || e.getDataType() == GameSource.Type.altered, comparator, e -> {
-            result.add(new Section<E>(GAME_SOURCE_HEADER, e -> true, comparator, e -> {
-                String desc = normalizeDesc(e.getDesc());
-                return e.getDataType() == GameSource.Type.altered ? desc + " (A)" : desc;
-            }));
-            return result;
-        }
-
-        /**
          * Builds a locale-aware comparator for normalized element descriptions.
          */
-        private static <E extends GameDataElement> Comparator<E> buildComparator() {
+        static <E extends GameDataElement> Comparator<E> buildComparator() {
             final Collator collator = Collator.getInstance(Locale.getDefault());
             collator.setStrength(Collator.PRIMARY);
             return (o1, o2) -> {
@@ -1283,11 +1260,23 @@ public abstract class Editor extends JPanel implements ProjectElementListener {
                     }
                 }
                 sectionRows.sort(section.comparator);
-                rows.add(Row.header(section.headerLabel));
+                if (section.headerLabel != null && !section.headerLabel.isEmpty()) {
+                    rows.add(Row.header(section.headerLabel));
+                }
                 for (E item : sectionRows) {
                     rows.add(Row.item(item, section.displayTextMapper.apply(item)));
                 }
             }
+        }
+
+        /**
+         * Returns the default single-section view used when no custom sections are provided.
+         */
+        private static <E extends GameDataElement> List<Section<E>> defaultSections() {
+            Comparator<E> comparator = buildComparator();
+            List<Section<E>> result = new ArrayList<Section<E>>();
+            result.add(new Section<E>(null, e -> true, comparator, e -> normalizeDesc(e.getDesc())));
+            return result;
         }
 
         /**
@@ -1321,7 +1310,7 @@ public abstract class Editor extends JPanel implements ProjectElementListener {
         /**
          * Normalizes a description for stable alphabetical ordering.
          */
-        private static String normalizeDesc(String desc) {
+        static String normalizeDesc(String desc) {
             if (desc == null) return "";
             String d = desc.trim();
             // strip leading markers like '*' that indicate modified/unsaved
@@ -1426,6 +1415,8 @@ public abstract class Editor extends JPanel implements ProjectElementListener {
     public static class GDERenderer extends DefaultListCellRenderer {
 
         private static final long serialVersionUID = 6819681566800482793L;
+        private static final Color ALTERED_HIGHLIGHT = new Color(255, 255, 0, 48);
+        private static final Color CREATED_HIGHLIGHT = new Color(0, 255, 0, 48);
 
         private boolean includeType;
         private boolean writable;
@@ -1458,6 +1449,7 @@ public abstract class Editor extends JPanel implements ProjectElementListener {
                 }
             }
             JLabel label = (JLabel) super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
+            label.setOpaque(true);
             if (value == null) {
                 label.setText("None set" + (writable ? "... Click on the button to create one." : ""));
             } else {
@@ -1487,10 +1479,48 @@ public abstract class Editor extends JPanel implements ProjectElementListener {
                 } else {
                     label.setIcon(new ImageIcon(((GameDataElement) value).getIcon()));
                 }
+                applyTypeHighlight(label, (GameDataElement) value, isSelected);
             }
             return label;
         }
 
+        private void applyTypeHighlight(JLabel label, GameDataElement value, boolean isSelected) {
+            if (isSelected) return;
+            if (value.getDataType() == GameSource.Type.altered) {
+                label.setBackground(ALTERED_HIGHLIGHT);
+            } else if (value.getDataType() == GameSource.Type.created) {
+                label.setBackground(CREATED_HIGHLIGHT);
+            }
+        }
+
+    }
+
+    /**
+     * Builds the default GDE combo sections used by the shared editors.
+     */
+    static <E extends GameDataElement> List<SortedGDEComboModel.Section<E>> createGDEComboSections() {
+        Comparator<E> comparator = SortedGDEComboModel.buildComparator();
+        List<SortedGDEComboModel.Section<E>> result = new ArrayList<SortedGDEComboModel.Section<E>>();
+        result.add(new SortedGDEComboModel.Section<E>(SortedGDEComboModel.PROJECT_HEADER,
+                e -> e.getDataType() == GameSource.Type.altered || e.getDataType() == GameSource.Type.created,
+                comparator,
+                e -> {
+                    String desc = SortedGDEComboModel.normalizeDesc(e.getDesc());
+                    return switch (e.getDataType()) {
+                        case created -> desc; //+ " (C)";
+                        case altered -> desc; //+ " (A)";
+                        default -> desc;
+                    };
+                }));
+        result.add(new SortedGDEComboModel.Section<E>(SortedGDEComboModel.GAME_SOURCE_HEADER,
+                e -> true,
+                comparator,
+                e -> {
+                    String desc = SortedGDEComboModel.normalizeDesc(e.getDesc());
+                    //return e.getDataType() == GameSource.Type.altered ? desc + " (A)" : desc;
+                    return desc;
+                }));
+        return result;
     }
 
     /**

--- a/src/com/gpl/rpg/atcontentstudio/ui/Editor.java
+++ b/src/com/gpl/rpg/atcontentstudio/ui/Editor.java
@@ -787,8 +787,7 @@ public abstract class Editor extends JPanel implements ProjectElementListener {
         gdePane.setLayout(new JideBoxLayout(gdePane, JideBoxLayout.LINE_AXIS, 6));
         JLabel gdeLabel = new JLabel(label);
         gdePane.add(gdeLabel, JideBoxLayout.FIX);
-        @SuppressWarnings({"rawtypes", "unchecked"})
-        final GDEComboModel wrappedModel = new SortedGDEComboModel(comboModel);
+        final SortedGDEComboModel<? extends GameDataElement> wrappedModel = new SortedGDEComboModel<>(comboModel);
         final MyComboBox gdeBox = new MyComboBox(dataClass, wrappedModel);
         gdeBox.setRenderer(new GDERenderer(false, writable));
         new ComboBoxSearchable(gdeBox) {
@@ -805,10 +804,10 @@ public abstract class Editor extends JPanel implements ProjectElementListener {
         goToGde.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent e) {
-                GameDataElement selected = ((GameDataElement) comboModel.getSelectedItem());
+                GameDataElement selected = wrappedModel.getSelectedDelegate();
                 if (selected != null) {
-                    ATContentStudio.frame.openEditor(((GameDataElement) comboModel.getSelectedItem()));
-                    ATContentStudio.frame.selectInTree((GameDataElement) comboModel.getSelectedItem());
+                    ATContentStudio.frame.openEditor(selected);
+                    ATContentStudio.frame.selectInTree(selected);
                 } else if (writable) {
                     JSONCreationWizard wizard = new JSONCreationWizard(((GameDataElement) target).getProject(), dataClass);
                     wizard.addCreationListener(new JSONCreationWizard.CreationCompletedListener() {
@@ -826,14 +825,14 @@ public abstract class Editor extends JPanel implements ProjectElementListener {
         gdeBox.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent e) {
-                if (gdeBox.getModel().getSelectedItem() == null) {
+                if (wrappedModel.getSelectedDelegate() == null) {
                     goToGde.setIcon((writable ? new ImageIcon(DefaultIcons.getCreateIcon()) : null));
                     goToGde.setEnabled(writable);
                 } else {
-                    goToGde.setIcon(new ImageIcon(((GameDataElement) comboModel.getSelectedItem()).getIcon()));
+                    goToGde.setIcon(new ImageIcon(wrappedModel.getSelectedDelegate().getIcon()));
                     goToGde.setEnabled(true);
                 }
-                listener.valueChanged(gdeBox, gdeBox.getModel().getSelectedItem());
+                listener.valueChanged(gdeBox, wrappedModel.getSelectedDelegate());
             }
         });
         JButton nullify = new JButton(new ImageIcon(DefaultIcons.getNullifyIcon()));
@@ -988,7 +987,7 @@ public abstract class Editor extends JPanel implements ProjectElementListener {
 
         private static final long serialVersionUID = 1L;
         public static final String PROJECT_HEADER = "Project Elements";
-        public static final String GAME_SOURCE_HEADER = "Game Source Elements";
+        public static final String GAME_SOURCE_HEADER = "All Elements";
 
         private final GDEComboModel<E> source;
         private final List<Section<E>> sections;
@@ -1012,24 +1011,28 @@ public abstract class Editor extends JPanel implements ProjectElementListener {
             this.source = source;
             this.sections = new ArrayList<Section<E>>(sections);
             rebuild();
+            syncSelectedRowFromSource();
 
             // Listen to the source model so we rebuild when it changes indirectly.
             source.addListDataListener(new javax.swing.event.ListDataListener() {
                 @Override
                 public void intervalAdded(javax.swing.event.ListDataEvent e) {
                     rebuild();
+                    syncSelectedRowFromSource();
                     fireContentsChanged(SortedGDEComboModel.this, 0, Math.max(0, getSize() - 1));
                 }
 
                 @Override
                 public void intervalRemoved(javax.swing.event.ListDataEvent e) {
                     rebuild();
+                    syncSelectedRowFromSource();
                     fireContentsChanged(SortedGDEComboModel.this, 0, Math.max(0, getSize() - 1));
                 }
 
                 @Override
                 public void contentsChanged(javax.swing.event.ListDataEvent e) {
                     rebuild();
+                    syncSelectedRowFromSource();
                     fireContentsChanged(SortedGDEComboModel.this, 0, Math.max(0, getSize() - 1));
                 }
             });
@@ -1240,7 +1243,8 @@ public abstract class Editor extends JPanel implements ProjectElementListener {
                 };
                 return desc;
             }));
-            result.add(new Section<E>(GAME_SOURCE_HEADER, e -> e.getDataType() == GameSource.Type.source || e.getDataType() == GameSource.Type.altered, comparator, e -> {
+            //result.add(new Section<E>(GAME_SOURCE_HEADER, e -> e.getDataType() == GameSource.Type.source || e.getDataType() == GameSource.Type.altered, comparator, e -> {
+            result.add(new Section<E>(GAME_SOURCE_HEADER, e -> true, comparator, e -> {
                 String desc = normalizeDesc(e.getDesc());
                 return e.getDataType() == GameSource.Type.altered ? desc + " (A)" : desc;
             }));
@@ -1284,6 +1288,34 @@ public abstract class Editor extends JPanel implements ProjectElementListener {
                     rows.add(Row.item(item, section.displayTextMapper.apply(item)));
                 }
             }
+        }
+
+        /**
+         * Re-syncs the selected row object from the source model's underlying element.
+         */
+        private void syncSelectedRowFromSource() {
+            this.selected = findRowValue(source.getSelectedItem());
+        }
+
+        /**
+         * Finds the exposed row object for a real element from the source model.
+         */
+        private E findRowValue(Object item) {
+            Row<E> row = findRow(item);
+            return row == null ? null : (E) row.asComboValue();
+        }
+
+        /**
+         * Finds the row wrapper that corresponds to the supplied item or wrapper.
+         */
+        private Row<E> findRow(Object item) {
+            if (item == null) return null;
+            for (Row<E> row : rows) {
+                if (row.element == item || row.item == item) {
+                    return row;
+                }
+            }
+            return null;
         }
 
         /**
@@ -1336,12 +1368,20 @@ public abstract class Editor extends JPanel implements ProjectElementListener {
                 fireContentsChanged(this, -1, -1);
                 return;
             }
-            if (anItem instanceof ItemElement) {
-                anItem = ((ItemElement) anItem).delegate;
+            Row<E> row = findRow(anItem);
+            if (row != null && row.selectable) {
+                source.setSelectedItem(row.item);
+                this.selected = (E) row.asComboValue();
+                fireContentsChanged(this, -1, -1);
+                return;
             }
-            // delegate selection to the source model so external callers see the same selected item
-            source.setSelectedItem(anItem);
-            this.selected = (E) anItem;
+            if (anItem == null) {
+                source.setSelectedItem(null);
+                this.selected = null;
+            } else {
+                source.setSelectedItem(anItem);
+                this.selected = findRowValue(anItem);
+            }
             fireContentsChanged(this, -1, -1);
         }
 
@@ -1350,7 +1390,14 @@ public abstract class Editor extends JPanel implements ProjectElementListener {
          */
         @Override
         public Object getSelectedItem() {
-            return source.getSelectedItem();
+            return selected;
+        }
+
+        /**
+         * Returns the real underlying element selected in the source model.
+         */
+        public E getSelectedDelegate() {
+            return source.selected;
         }
 
         /**
@@ -1412,7 +1459,7 @@ public abstract class Editor extends JPanel implements ProjectElementListener {
             }
             JLabel label = (JLabel) super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
             if (value == null) {
-                label.setText("None set." + (writable ? ". Click on the button to create one." : ""));
+                label.setText("None set" + (writable ? "... Click on the button to create one." : ""));
             } else {
                 if (includeType && ((GameDataElement) value).getDataType() != null) {
                     if (value instanceof QuestStage) {

--- a/src/com/gpl/rpg/atcontentstudio/ui/Editor.java
+++ b/src/com/gpl/rpg/atcontentstudio/ui/Editor.java
@@ -3,6 +3,7 @@ package com.gpl.rpg.atcontentstudio.ui;
 import com.gpl.rpg.atcontentstudio.ATContentStudio;
 import com.gpl.rpg.atcontentstudio.Notification;
 import com.gpl.rpg.atcontentstudio.model.GameDataElement;
+import com.gpl.rpg.atcontentstudio.model.GameSource;
 import com.gpl.rpg.atcontentstudio.model.Project;
 import com.gpl.rpg.atcontentstudio.model.ProjectElementListener;
 import com.gpl.rpg.atcontentstudio.model.SaveEvent;
@@ -26,6 +27,7 @@ import java.net.URISyntaxException;
 import java.util.List;
 import java.util.*;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.regex.Matcher;
 import java.text.Collator;
@@ -928,6 +930,9 @@ public abstract class Editor extends JPanel implements ProjectElementListener {
         return list;
     }
 
+    /**
+     * Base combo model for selecting project {@link GameDataElement}s with a null row at index 0.
+     */
     public static abstract class GDEComboModel<E extends GameDataElement> extends AbstractListModel<E> implements ComboBoxModel<E> {
 
         private static final long serialVersionUID = -5854574666510314715L;
@@ -975,25 +980,37 @@ public abstract class Editor extends JPanel implements ProjectElementListener {
     }
 
     /**
-     * Wrapper around a GDEComboModel that presents the same elements but
-     * sorted by their description (as returned by getDesc()).
-     *
-     * This keeps the same ComboBoxModel API so callers (e.g. MyComboBox)
-     * can cast to GDEComboModel and call itemAdded/itemRemoved; the wrapper
-     * rebuilds a sorted view and fires change events when the underlying
-     * model changes.
+     * Presents a grouped, sorted view of a {@link GDEComboModel} without changing the
+     * underlying project order.
      */
     @SuppressWarnings({"rawtypes", "unchecked"})
     public static class SortedGDEComboModel<E extends GameDataElement> extends GDEComboModel<E> {
 
         private static final long serialVersionUID = 1L;
+        public static final String PROJECT_HEADER = "Project Elements";
+        public static final String GAME_SOURCE_HEADER = "Game Source Elements";
 
         private final GDEComboModel<E> source;
-        private final java.util.List<E> sorted = new ArrayList<E>();
+        private final List<Section<E>> sections;
+        private final List<Row<E>> rows = new ArrayList<Row<E>>();
 
+        /**
+         * Creates the default two-section view: Project, and Game Source.
+         */
         public SortedGDEComboModel(GDEComboModel<E> source) {
+            this(source, defaultSections());
+        }
+
+        /**
+         * Creates a grouped view using the supplied section definitions.
+         *
+         * @param source the underlying combo model
+         * @param sections ordered section definitions to flatten into rows
+         */
+        public SortedGDEComboModel(GDEComboModel<E> source, List<Section<E>> sections) {
             super(source.project, source.selected);
             this.source = source;
+            this.sections = new ArrayList<Section<E>>(sections);
             rebuild();
 
             // Listen to the source model so we rebuild when it changes indirectly.
@@ -1001,41 +1018,278 @@ public abstract class Editor extends JPanel implements ProjectElementListener {
                 @Override
                 public void intervalAdded(javax.swing.event.ListDataEvent e) {
                     rebuild();
-                    fireContentsChanged(SortedGDEComboModel.this, 0, getSize() - 1);
+                    fireContentsChanged(SortedGDEComboModel.this, 0, Math.max(0, getSize() - 1));
                 }
 
                 @Override
                 public void intervalRemoved(javax.swing.event.ListDataEvent e) {
                     rebuild();
-                    fireContentsChanged(SortedGDEComboModel.this, 0, getSize() - 1);
+                    fireContentsChanged(SortedGDEComboModel.this, 0, Math.max(0, getSize() - 1));
                 }
 
                 @Override
                 public void contentsChanged(javax.swing.event.ListDataEvent e) {
                     rebuild();
-                    fireContentsChanged(SortedGDEComboModel.this, 0, getSize() - 1);
+                    fireContentsChanged(SortedGDEComboModel.this, 0, Math.max(0, getSize() - 1));
                 }
             });
         }
 
-        private void rebuild() {
-            sorted.clear();
-            int s = source.getSize();
-            for (int i = 1; i < s; i++) {
-                E e = source.getElementAt(i);
-                if (e != null) sorted.add(e);
+        /**
+         * Describes one headered group in the flattened combo view.
+         * Each section controls membership, ordering, and display text for its rows.
+         */
+        public static class Section<E extends GameDataElement> {
+
+            private final String headerLabel;
+            private final Predicate<? super E> filter;
+            private final Comparator<? super E> comparator;
+            private final Function<? super E, String> displayTextMapper;
+
+            /**
+             * Defines one headered section in the flattened combo model.
+             *
+             * @param headerLabel the row text shown before the section contents
+             * @param filter which elements belong to this section
+             * @param comparator ordering used within the section
+             * @param displayTextMapper display label used for the row
+             */
+            public Section(String headerLabel,
+                           Predicate<? super E> filter,
+                           Comparator<? super E> comparator,
+                           Function<? super E, String> displayTextMapper) {
+                this.headerLabel = headerLabel;
+                this.filter = filter;
+                this.comparator = comparator;
+                this.displayTextMapper = displayTextMapper;
             }
-            // Locale-aware comparison on a normalized description key.
+        }
+
+        /**
+         * Internal flattened row representation used by the sorted combo model.
+         */
+        private static final class Row<E extends GameDataElement> {
+            private final GameDataElement element;
+            private final E item;
+            private final boolean selectable;
+
+            private Row(GameDataElement element, E item, boolean selectable) {
+                this.element = element;
+                this.item = item;
+                this.selectable = selectable;
+            }
+
+            /**
+             * Returns a non-selectable header row.
+             */
+            private static <E extends GameDataElement> Row<E> header(String headerLabel) {
+                return new Row<E>(new HeaderElement(headerLabel), null, false);
+            }
+
+            /**
+             * Returns a selectable row for a real element.
+             */
+            private static <E extends GameDataElement> Row<E> item(E item, String displayLabel) {
+                return new Row<E>(new ItemElement(item, displayLabel), item, true);
+            }
+
+            /**
+             * Returns the object exposed to the combo box for this row.
+             */
+            private GameDataElement asComboValue() {
+                return element;
+            }
+        }
+
+        /**
+         * Lightweight wrapper used for synthetic combo rows.
+         * Headers and display-label overrides live here, while most behavior delegates to the real element.
+         */
+        private static abstract class DelegatingElement extends GameDataElement {
+
+            private static final long serialVersionUID = 1L;
+            protected final GameDataElement delegate;
+            private final String desc;
+
+            /**
+             * Creates a lightweight row wrapper around a real element.
+             */
+            private DelegatingElement(GameDataElement delegate, String desc) {
+                this.delegate = delegate;
+                this.desc = desc == null ? "" : desc;
+            }
+
+            /**
+             * Returns the underlying row label.
+             */
+            @Override
+            public String getDesc() {
+                return desc;
+            }
+
+            @Override
+            public void parse() {
+            }
+
+            @Override
+            public void link() {
+            }
+
+            @Override
+            public GameDataElement clone() {
+                return delegate == null ? this : delegate.clone();
+            }
+
+            @Override
+            public void elementChanged(GameDataElement oldOne, GameDataElement newOne) {
+            }
+
+            @Override
+            public String getProjectFilename() {
+                return delegate == null ? "" : delegate.getProjectFilename();
+            }
+
+            @Override
+            public com.gpl.rpg.atcontentstudio.model.gamedata.GameDataSet getDataSet() {
+                return delegate == null ? null : delegate.getDataSet();
+            }
+
+            @Override
+            public void save() {
+                if (delegate != null) delegate.save();
+            }
+
+            @Override
+            public List<SaveEvent> attemptSave() {
+                return delegate == null ? null : delegate.attemptSave();
+            }
+
+            @Override
+            public GameSource.Type getDataType() {
+                return delegate == null ? null : delegate.getDataType();
+            }
+
+            @Override
+            public Image getIcon() {
+                return delegate == null ? null : delegate.getIcon();
+            }
+
+            @Override
+            public boolean isEmpty() {
+                return delegate != null && delegate.isEmpty();
+            }
+        }
+
+        /**
+         * Non-selectable row used as a section header in the combo popup.
+         */
+        private static final class HeaderElement extends DelegatingElement {
+
+            private static final long serialVersionUID = 1L;
+
+            private HeaderElement(String label) {
+                super(null, label);
+            }
+        }
+
+        /**
+         * Selectable row wrapper for a real project element.
+         */
+        private static final class ItemElement extends DelegatingElement {
+
+            private static final long serialVersionUID = 1L;
+            private final boolean alteredMarker;
+
+            private ItemElement(GameDataElement delegate, String label) {
+                super(delegate, label);
+                this.alteredMarker = label != null && label.startsWith("*");
+            }
+
+            @Override
+            public void save() {
+                if (delegate != null) delegate.save();
+            }
+
+            @Override
+            public List<SaveEvent> attemptSave() {
+                return delegate == null ? null : delegate.attemptSave();
+            }
+
+            @Override
+            public boolean isEmpty() {
+                return delegate != null && delegate.isEmpty();
+            }
+
+            public boolean isAlteredMarker() {
+                return alteredMarker;
+            }
+        }
+
+        /**
+         * Returns the section definitions used by the default model.
+         */
+        private static <E extends GameDataElement> List<Section<E>> defaultSections() {
+            Comparator<E> comparator = buildComparator();
+            List<Section<E>> result = new ArrayList<Section<E>>();
+            result.add(new Section<E>(PROJECT_HEADER, e -> e.getDataType() == GameSource.Type.altered  || e.getDataType() == GameSource.Type.created, comparator, e -> {
+                String desc = normalizeDesc(e.getDesc());
+                desc = switch (e.getDataType()) {
+                    case created -> desc + " (C)";
+                    case altered -> desc + " (A)";
+                    default -> desc;
+                };
+                return desc;
+            }));
+            result.add(new Section<E>(GAME_SOURCE_HEADER, e -> e.getDataType() == GameSource.Type.source || e.getDataType() == GameSource.Type.altered, comparator, e -> {
+                String desc = normalizeDesc(e.getDesc());
+                return e.getDataType() == GameSource.Type.altered ? desc + " (A)" : desc;
+            }));
+            return result;
+        }
+
+        /**
+         * Builds a locale-aware comparator for normalized element descriptions.
+         */
+        private static <E extends GameDataElement> Comparator<E> buildComparator() {
             final Collator collator = Collator.getInstance(Locale.getDefault());
-            collator.setStrength(Collator.PRIMARY); // basic comparison (ignore case/diacritics)
-            sorted.sort((o1, o2) -> {
+            collator.setStrength(Collator.PRIMARY);
+            return (o1, o2) -> {
                 String a = normalizeDesc(o1 == null ? null : o1.getDesc());
                 String b = normalizeDesc(o2 == null ? null : o2.getDesc());
                 return collator.compare(a, b);
-            });
+            };
         }
 
-        private String normalizeDesc(String desc) {
+        /**
+         * Rebuilds the flattened row list from the source model.
+         */
+        private void rebuild() {
+            rows.clear();
+            int s = source.getSize();
+            List<E> all = new ArrayList<E>();
+            for (int i = 1; i < s; i++) {
+                E e = source.getElementAt(i);
+                if (e != null) all.add(e);
+            }
+            for (Section<E> section : sections) {
+                List<E> sectionRows = new ArrayList<E>();
+                for (E item : all) {
+                    if (section.filter.test(item)) {
+                        sectionRows.add(item);
+                    }
+                }
+                sectionRows.sort(section.comparator);
+                rows.add(Row.header(section.headerLabel));
+                for (E item : sectionRows) {
+                    rows.add(Row.item(item, section.displayTextMapper.apply(item)));
+                }
+            }
+        }
+
+        /**
+         * Normalizes a description for stable alphabetical ordering.
+         */
+        private static String normalizeDesc(String desc) {
             if (desc == null) return "";
             String d = desc.trim();
             // strip leading markers like '*' that indicate modified/unsaved
@@ -1047,50 +1301,81 @@ public abstract class Editor extends JPanel implements ProjectElementListener {
             return d;
         }
 
+        /**
+         * Returns the row count including the null sentinel at index 0.
+         */
         @Override
         public int getSize() {
-            // +1 for the null sentinel at index 0
-            return sorted.size() + 1;
+            return rows.size() + 1;
         }
 
+        /**
+         * Returns the row at the specified combo-box index.
+         */
         @Override
         public E getElementAt(int index) {
             if (index == 0) return null;
-            return sorted.get(index - 1);
+            return (E) rows.get(index - 1).asComboValue();
         }
 
+        /**
+         * Returns the underlying selectable element for the row index.
+         */
         @Override
         public E getTypedElementAt(int index) {
-            return sorted.get(index);
+            Row<E> row = rows.get(index);
+            return row.selectable ? row.item : null;
         }
 
+        /**
+         * Updates the selected item while ignoring header rows.
+         */
         @Override
         public void setSelectedItem(Object anItem) {
+            if (anItem instanceof HeaderElement) {
+                fireContentsChanged(this, -1, -1);
+                return;
+            }
+            if (anItem instanceof ItemElement) {
+                anItem = ((ItemElement) anItem).delegate;
+            }
             // delegate selection to the source model so external callers see the same selected item
             source.setSelectedItem(anItem);
             this.selected = (E) anItem;
             fireContentsChanged(this, -1, -1);
         }
 
+        /**
+         * Returns the selected underlying element from the source model.
+         */
         @Override
         public Object getSelectedItem() {
             return source.getSelectedItem();
         }
 
+        /**
+         * Rebuilds the view when the source model adds an item.
+         */
         @Override
         public void itemAdded(E item, int index) {
             // when underlying content changes, rebuild sorted view and notify listeners
             rebuild();
-            fireContentsChanged(this, 0, getSize() - 1);
+            fireContentsChanged(this, 0, Math.max(0, getSize() - 1));
         }
 
+        /**
+         * Rebuilds the view when the source model removes an item.
+         */
         @Override
         public void itemRemoved(E item, int index) {
             rebuild();
-            fireContentsChanged(this, 0, getSize() - 1);
+            fireContentsChanged(this, 0, Math.max(0, getSize() - 1));
         }
     }
 
+    /**
+     * Renders GDE combo rows, including null entries, section headers, icons, and type labels.
+     */
     public static class GDERenderer extends DefaultListCellRenderer {
 
         private static final long serialVersionUID = 6819681566800482793L;
@@ -1098,18 +1383,36 @@ public abstract class Editor extends JPanel implements ProjectElementListener {
         private boolean includeType;
         private boolean writable;
 
+        /**
+         * Creates a renderer that can optionally prefix entries with their type.
+         */
         public GDERenderer(boolean includeType, boolean writable) {
             super();
             this.includeType = includeType;
             this.writable = writable;
         }
 
+        /**
+         * Renders header rows distinctly from normal combo-box items.
+         */
         @SuppressWarnings("rawtypes")
         @Override
         public Component getListCellRendererComponent(JList list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
+            if (value instanceof SortedGDEComboModel.DelegatingElement) {
+                SortedGDEComboModel.DelegatingElement row = (SortedGDEComboModel.DelegatingElement) value;
+                if (row instanceof SortedGDEComboModel.HeaderElement) {
+                    JLabel header = new JLabel(row.getDesc());
+                    header.setOpaque(true);
+                    header.setBackground(UIManager.getColor("ComboBox.background"));
+                    header.setForeground(UIManager.getColor("Label.disabledForeground"));
+                    header.setFont(header.getFont().deriveFont(Font.BOLD));
+                    header.setBorder(BorderFactory.createEmptyBorder(2, 8, 2, 8));
+                    return header;
+                }
+            }
             JLabel label = (JLabel) super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
             if (value == null) {
-                label.setText("None" + (writable ? ". Click on the button to create one." : ""));
+                label.setText("None set." + (writable ? ". Click on the button to create one." : ""));
             } else {
                 if (includeType && ((GameDataElement) value).getDataType() != null) {
                     if (value instanceof QuestStage) {
@@ -1143,6 +1446,9 @@ public abstract class Editor extends JPanel implements ProjectElementListener {
 
     }
 
+    /**
+     * Combo model for the stages of the currently selected quest.
+     */
     public static class QuestStageComboModel extends AbstractListModel<QuestStage> implements ComboBoxModel<QuestStage> {
 
         private static final long serialVersionUID = -5854574666510314715L;
@@ -1201,6 +1507,9 @@ public abstract class Editor extends JPanel implements ProjectElementListener {
     }
 
 
+    /**
+     * List model backed by the backlink set of a single {@link GameDataElement}.
+     */
     public static class GDEBacklinksListModel implements ListenerCollectionModel<GameDataElement> {
 
         GameDataElement source;
@@ -1236,6 +1545,9 @@ public abstract class Editor extends JPanel implements ProjectElementListener {
     }
 
     @SuppressWarnings({"rawtypes", "unchecked"})
+    /**
+     * Combo box that listens for project element add/remove events and forwards them to its model.
+     */
     public class MyComboBox extends JComboBox implements ProjectElementListener {
 
         private static final long serialVersionUID = -4184228604170642567L;

--- a/src/com/gpl/rpg/atcontentstudio/ui/Editor.java
+++ b/src/com/gpl/rpg/atcontentstudio/ui/Editor.java
@@ -92,23 +92,23 @@ public abstract class Editor extends JPanel implements ProjectElementListener {
         }
     }
 
-    public static boolean useEnumValuesInComboboxes() {
+    public static boolean showEnumNamesInComboboxes() {
         return Workspace.activeWorkspace != null
                 && Workspace.activeWorkspace.settings != null
-                && Boolean.TRUE.equals(Workspace.activeWorkspace.settings.useEnumValuesInComboboxes.getCurrentValue());
+                && Boolean.TRUE.equals(Workspace.activeWorkspace.settings.showEnumNamesInComboboxes.getCurrentValue());
     }
 
     /**
-     * Returns a function that generates labels for enum values based on the current workspace settings.
-     * If the setting to use enum values in comboboxes is enabled, the label will include both the enum name and its description.
+     * Returns a function that generates labels for enum names based on the current workspace settings.
+     * If the setting to show enum names in comboboxes is enabled, the label will include both the enum name and its description.
      * Otherwise, it will only use the description.
      *
      * @param <E> The type of the enum.
      * @param descriptionGetter A function that provides the description for each enum value.
-     * @return A function that generates labels for enum values.
+     * @return A function that generates labels for enum names.
      */
     public static <E extends Enum<E>> Function<E, String> getEnumLabelGetter(Function<E, String> descriptionGetter) {
-        if (useEnumValuesInComboboxes()) {
+        if (showEnumNamesInComboboxes()) {
             return e -> e == null ? null : e.name() + " - " + descriptionGetter.apply(e);
         } else {
             return descriptionGetter;

--- a/src/com/gpl/rpg/atcontentstudio/ui/Editor.java
+++ b/src/com/gpl/rpg/atcontentstudio/ui/Editor.java
@@ -1396,6 +1396,7 @@ public abstract class Editor extends JPanel implements ProjectElementListener {
         public void itemAdded(E item, int index) {
             // when underlying content changes, rebuild sorted view and notify listeners
             rebuild();
+            syncSelectedRowFromSource();
             fireContentsChanged(this, 0, Math.max(0, getSize() - 1));
         }
 
@@ -1405,6 +1406,7 @@ public abstract class Editor extends JPanel implements ProjectElementListener {
         @Override
         public void itemRemoved(E item, int index) {
             rebuild();
+            syncSelectedRowFromSource();
             fireContentsChanged(this, 0, Math.max(0, getSize() - 1));
         }
     }

--- a/src/com/gpl/rpg/atcontentstudio/ui/Editor.java
+++ b/src/com/gpl/rpg/atcontentstudio/ui/Editor.java
@@ -92,6 +92,29 @@ public abstract class Editor extends JPanel implements ProjectElementListener {
         }
     }
 
+    public static boolean useEnumValuesInComboboxes() {
+        return Workspace.activeWorkspace != null
+                && Workspace.activeWorkspace.settings != null
+                && Boolean.TRUE.equals(Workspace.activeWorkspace.settings.useEnumValuesInComboboxes.getCurrentValue());
+    }
+
+    /**
+     * Returns a function that generates labels for enum values based on the current workspace settings.
+     * If the setting to use enum values in comboboxes is enabled, the label will include both the enum name and its description.
+     * Otherwise, it will only use the description.
+     *
+     * @param <E> The type of the enum.
+     * @param descriptionGetter A function that provides the description for each enum value.
+     * @return A function that generates labels for enum values.
+     */
+    public static <E extends Enum<E>> Function<E, String> getEnumLabelGetter(Function<E, String> descriptionGetter) {
+        if (useEnumValuesInComboboxes()) {
+            return e -> e == null ? null : e.name() + " - " + descriptionGetter.apply(e);
+        } else {
+            return descriptionGetter;
+        }
+    }
+
 
     public static JTextField addLabelField(JPanel pane, String label, String value) {
         return addTextField(pane, label, value, false, nullListener);

--- a/src/com/gpl/rpg/atcontentstudio/ui/Editor.java
+++ b/src/com/gpl/rpg/atcontentstudio/ui/Editor.java
@@ -22,6 +22,7 @@ import javax.swing.text.JTextComponent;
 import java.awt.*;
 import java.awt.event.*;
 import java.io.IOException;
+import java.io.Serial;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
@@ -1110,6 +1111,7 @@ public abstract class Editor extends JPanel implements ProjectElementListener {
          */
         private static abstract class DelegatingElement extends GameDataElement {
 
+            @Serial
             private static final long serialVersionUID = 1L;
             protected final GameDataElement delegate;
             private final String desc;
@@ -1188,6 +1190,7 @@ public abstract class Editor extends JPanel implements ProjectElementListener {
          */
         private static final class HeaderElement extends DelegatingElement {
 
+            @Serial
             private static final long serialVersionUID = 1L;
 
             private HeaderElement(String label) {
@@ -1200,32 +1203,13 @@ public abstract class Editor extends JPanel implements ProjectElementListener {
          */
         private static final class ItemElement extends DelegatingElement {
 
+            @Serial
             private static final long serialVersionUID = 1L;
-            private final boolean alteredMarker;
 
             private ItemElement(GameDataElement delegate, String label) {
                 super(delegate, label);
-                this.alteredMarker = label != null && label.startsWith("*");
             }
 
-            @Override
-            public void save() {
-                if (delegate != null) delegate.save();
-            }
-
-            @Override
-            public List<SaveEvent> attemptSave() {
-                return delegate == null ? null : delegate.attemptSave();
-            }
-
-            @Override
-            public boolean isEmpty() {
-                return delegate != null && delegate.isEmpty();
-            }
-
-            public boolean isAlteredMarker() {
-                return alteredMarker;
-            }
         }
 
         /**
@@ -1435,7 +1419,6 @@ public abstract class Editor extends JPanel implements ProjectElementListener {
         /**
          * Renders header rows distinctly from normal combo-box items.
          */
-        @SuppressWarnings("rawtypes")
         @Override
         public Component getListCellRendererComponent(JList list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
             if (value instanceof SortedGDEComboModel.DelegatingElement) {

--- a/src/com/gpl/rpg/atcontentstudio/ui/WorkspaceSettingsEditor.java
+++ b/src/com/gpl/rpg/atcontentstudio/ui/WorkspaceSettingsEditor.java
@@ -19,6 +19,7 @@ public class WorkspaceSettingsEditor extends JDialog {
     JTextField mapEditorCommandField;
     // Checkbox for the world map Ctrl-only zoom preference.
     JCheckBox zoomWorldMapOnlyWithCtrlBox;
+    JCheckBox useEnumValuesInComboboxes;
 
     JRadioButton useSystemDefaultImageViewerButton, useSystemDefaultImageEditorButton, useCustomImageEditorButton;
     JTextField imageEditorCommandField;
@@ -200,6 +201,9 @@ public class WorkspaceSettingsEditor extends JDialog {
         zoomWorldMapOnlyWithCtrlBox = new JCheckBox("Use Ctrl+Wheel to zoom World Map");
         pane.add(zoomWorldMapOnlyWithCtrlBox, JideBoxLayout.FIX);
 
+        useEnumValuesInComboboxes = new JCheckBox("Use Enum Values in Requirement, Reward, and Skill Comboboxes");
+        pane.add(useEnumValuesInComboboxes, JideBoxLayout.FIX);
+
         return pane;
     }
 
@@ -209,6 +213,7 @@ public class WorkspaceSettingsEditor extends JDialog {
         useCustomMapEditorButton.setSelected(!settings.useSystemDefaultMapEditor.getCurrentValue());
         mapEditorCommandField.setText(settings.mapEditorCommand.getCurrentValue());
         zoomWorldMapOnlyWithCtrlBox.setSelected(settings.zoomWorldMapOnlyWithCtrl.getCurrentValue());
+        useEnumValuesInComboboxes.setSelected(settings.useEnumValuesInComboboxes.getCurrentValue());
         //Images
         useSystemDefaultImageViewerButton.setSelected(settings.useSystemDefaultImageViewer.getCurrentValue());
         useSystemDefaultImageEditorButton.setSelected(settings.useSystemDefaultImageEditor.getCurrentValue());
@@ -235,6 +240,7 @@ public class WorkspaceSettingsEditor extends JDialog {
         settings.useSystemDefaultMapEditor.setCurrentValue(useSystemDefaultMapEditorButton.isSelected());
         settings.mapEditorCommand.setCurrentValue(mapEditorCommandField.getText());
         settings.zoomWorldMapOnlyWithCtrl.setCurrentValue(zoomWorldMapOnlyWithCtrlBox.isSelected());
+        settings.useEnumValuesInComboboxes.setCurrentValue(useEnumValuesInComboboxes.isSelected());
         //Images
         settings.useSystemDefaultImageViewer.setCurrentValue(useSystemDefaultImageViewerButton.isSelected());
         settings.useSystemDefaultImageEditor.setCurrentValue(useSystemDefaultImageEditorButton.isSelected());

--- a/src/com/gpl/rpg/atcontentstudio/ui/WorkspaceSettingsEditor.java
+++ b/src/com/gpl/rpg/atcontentstudio/ui/WorkspaceSettingsEditor.java
@@ -19,7 +19,7 @@ public class WorkspaceSettingsEditor extends JDialog {
     JTextField mapEditorCommandField;
     // Checkbox for the world map Ctrl-only zoom preference.
     JCheckBox zoomWorldMapOnlyWithCtrlBox;
-    JCheckBox useEnumValuesInComboboxes;
+    JCheckBox showEnumNamesInComboboxes;
 
     JRadioButton useSystemDefaultImageViewerButton, useSystemDefaultImageEditorButton, useCustomImageEditorButton;
     JTextField imageEditorCommandField;
@@ -201,8 +201,8 @@ public class WorkspaceSettingsEditor extends JDialog {
         zoomWorldMapOnlyWithCtrlBox = new JCheckBox("Use Ctrl+Wheel to zoom World Map");
         pane.add(zoomWorldMapOnlyWithCtrlBox, JideBoxLayout.FIX);
 
-        useEnumValuesInComboboxes = new JCheckBox("Use Enum Values in Requirement, Reward, and Skill Comboboxes");
-        pane.add(useEnumValuesInComboboxes, JideBoxLayout.FIX);
+        showEnumNamesInComboboxes = new JCheckBox("Show Enum Names in Requirement, Reward, and Skill Comboboxes");
+        pane.add(showEnumNamesInComboboxes, JideBoxLayout.FIX);
 
         return pane;
     }
@@ -213,7 +213,7 @@ public class WorkspaceSettingsEditor extends JDialog {
         useCustomMapEditorButton.setSelected(!settings.useSystemDefaultMapEditor.getCurrentValue());
         mapEditorCommandField.setText(settings.mapEditorCommand.getCurrentValue());
         zoomWorldMapOnlyWithCtrlBox.setSelected(settings.zoomWorldMapOnlyWithCtrl.getCurrentValue());
-        useEnumValuesInComboboxes.setSelected(settings.useEnumValuesInComboboxes.getCurrentValue());
+        showEnumNamesInComboboxes.setSelected(settings.showEnumNamesInComboboxes.getCurrentValue());
         //Images
         useSystemDefaultImageViewerButton.setSelected(settings.useSystemDefaultImageViewer.getCurrentValue());
         useSystemDefaultImageEditorButton.setSelected(settings.useSystemDefaultImageEditor.getCurrentValue());
@@ -240,7 +240,7 @@ public class WorkspaceSettingsEditor extends JDialog {
         settings.useSystemDefaultMapEditor.setCurrentValue(useSystemDefaultMapEditorButton.isSelected());
         settings.mapEditorCommand.setCurrentValue(mapEditorCommandField.getText());
         settings.zoomWorldMapOnlyWithCtrl.setCurrentValue(zoomWorldMapOnlyWithCtrlBox.isSelected());
-        settings.useEnumValuesInComboboxes.setCurrentValue(useEnumValuesInComboboxes.isSelected());
+        settings.showEnumNamesInComboboxes.setCurrentValue(showEnumNamesInComboboxes.isSelected());
         //Images
         settings.useSystemDefaultImageViewer.setCurrentValue(useSystemDefaultImageViewerButton.isSelected());
         settings.useSystemDefaultImageEditor.setCurrentValue(useSystemDefaultImageEditorButton.isSelected());

--- a/src/com/gpl/rpg/atcontentstudio/ui/WorkspaceSettingsEditor.java
+++ b/src/com/gpl/rpg/atcontentstudio/ui/WorkspaceSettingsEditor.java
@@ -17,6 +17,8 @@ public class WorkspaceSettingsEditor extends JDialog {
 
     JRadioButton useSystemDefaultMapEditorButton, useCustomMapEditorButton;
     JTextField mapEditorCommandField;
+    // Checkbox for the world map Ctrl-only zoom preference.
+    JCheckBox zoomWorldMapOnlyWithCtrlBox;
 
     JRadioButton useSystemDefaultImageViewerButton, useSystemDefaultImageEditorButton, useCustomImageEditorButton;
     JTextField imageEditorCommandField;
@@ -44,6 +46,7 @@ public class WorkspaceSettingsEditor extends JDialog {
 
 
         pane.add(getExternalToolsPane(), JideBoxLayout.FIX);
+        pane.add(getEditorBehaviorPane(), JideBoxLayout.FIX);
         pane.add(getInternetPane(), JideBoxLayout.FIX);
         pane.add(new JPanel(), JideBoxLayout.VARY);
 
@@ -190,11 +193,22 @@ public class WorkspaceSettingsEditor extends JDialog {
         return pane;
     }
 
+    public JPanel getEditorBehaviorPane() {
+        CollapsiblePanel pane = new CollapsiblePanel("Editor behavior");
+        pane.setLayout(new JideBoxLayout(pane, JideBoxLayout.PAGE_AXIS));
+
+        zoomWorldMapOnlyWithCtrlBox = new JCheckBox("Use Ctrl+Wheel to zoom World Map");
+        pane.add(zoomWorldMapOnlyWithCtrlBox, JideBoxLayout.FIX);
+
+        return pane;
+    }
+
     public void loadFromModel() {
         //Tiled
         useSystemDefaultMapEditorButton.setSelected(settings.useSystemDefaultMapEditor.getCurrentValue());
         useCustomMapEditorButton.setSelected(!settings.useSystemDefaultMapEditor.getCurrentValue());
         mapEditorCommandField.setText(settings.mapEditorCommand.getCurrentValue());
+        zoomWorldMapOnlyWithCtrlBox.setSelected(settings.zoomWorldMapOnlyWithCtrl.getCurrentValue());
         //Images
         useSystemDefaultImageViewerButton.setSelected(settings.useSystemDefaultImageViewer.getCurrentValue());
         useSystemDefaultImageEditorButton.setSelected(settings.useSystemDefaultImageEditor.getCurrentValue());
@@ -220,6 +234,7 @@ public class WorkspaceSettingsEditor extends JDialog {
         //Tiled
         settings.useSystemDefaultMapEditor.setCurrentValue(useSystemDefaultMapEditorButton.isSelected());
         settings.mapEditorCommand.setCurrentValue(mapEditorCommandField.getText());
+        settings.zoomWorldMapOnlyWithCtrl.setCurrentValue(zoomWorldMapOnlyWithCtrlBox.isSelected());
         //Images
         settings.useSystemDefaultImageViewer.setCurrentValue(useSystemDefaultImageViewerButton.isSelected());
         settings.useSystemDefaultImageEditor.setCurrentValue(useSystemDefaultImageEditorButton.isSelected());

--- a/src/com/gpl/rpg/atcontentstudio/ui/gamedataeditors/DialogueEditor.java
+++ b/src/com/gpl/rpg/atcontentstudio/ui/gamedataeditors/DialogueEditor.java
@@ -223,7 +223,7 @@ public class DialogueEditor extends JSONElementEditor {
                     Dialogue.Reward.RewardType.values(),
                     reward.type,
                     ((Dialogue) target).writable,
-                    Dialogue.Reward.RewardType::getDescription,
+                    getEnumLabelGetter(Dialogue.Reward.RewardType::getDescription),
                     listener
             );
             rewardsParamsPane = new JPanel();
@@ -422,7 +422,15 @@ public class DialogueEditor extends JSONElementEditor {
                     }
                     rewardMap = null;
                     rewardObjId = null;// addTextField(pane, "Skill ID: ", reward.reward_obj_id, writable, listener);
-                    rewardObjIdCombo = addEnumValueBoxWithDescriptions(pane, "Skill ID: ", Requirement.SkillID.values(), skillId, writable, Requirement.SkillID::getDescription, listener);
+                    rewardObjIdCombo = addEnumValueBoxWithDescriptions(
+                            pane,
+                            "Skill ID: ",
+                            Requirement.SkillID.values(),
+                            skillId,
+                            writable,
+                            getEnumLabelGetter(Requirement.SkillID::getDescription),
+                            listener
+                    );
                     rewardObj = null;
                     rewardValue = null;
                     break;
@@ -468,7 +476,7 @@ public class DialogueEditor extends JSONElementEditor {
                 Requirement.RequirementType.values(),
                 requirement == null ? null : requirement.type,
                 writable,
-                Requirement.RequirementType::getDescription,
+                getEnumLabelGetter(Requirement.RequirementType::getDescription),
                 listener
         );
 
@@ -772,7 +780,15 @@ public class DialogueEditor extends JSONElementEditor {
             removeElementListener(requirementObj);
         }
 
-        requirementTypeCombo = addEnumValueBoxWithDescriptions(pane, "Requirement type: ", Requirement.RequirementType.values(), requirement == null ? null : requirement.type, writable, Requirement.RequirementType::getDescription, listener);
+        requirementTypeCombo = addEnumValueBoxWithDescriptions(
+                pane,
+                "Requirement type: ",
+                Requirement.RequirementType.values(),
+                requirement == null ? null : requirement.type,
+                writable,
+                getEnumLabelGetter(Requirement.RequirementType::getDescription),
+                listener
+        );
         requirementParamsPane = new JPanel();
         requirementParamsPane.setLayout(new JideBoxLayout(requirementParamsPane, JideBoxLayout.PAGE_AXIS));
         updateRequirementParamsEditorPane(requirementParamsPane, requirement, listener);
@@ -834,7 +850,15 @@ public class DialogueEditor extends JSONElementEditor {
                     } catch (IllegalArgumentException e) {
                     }
                     requirementObj = null;
-                    requirementSkill = addEnumValueBoxWithDescriptions(pane, "Skill ID:", Requirement.SkillID.values(), skillId, writable, Requirement.SkillID::getDescription, listener);
+                    requirementSkill = addEnumValueBoxWithDescriptions(
+                            pane,
+                            "Skill ID:",
+                            Requirement.SkillID.values(),
+                            skillId,
+                            writable,
+                            getEnumLabelGetter(Requirement.SkillID::getDescription),
+                            listener
+                    );
                     requirementObjId = null;//addTextField(pane, "Skill ID:", requirement.required_obj_id, writable, listener);
                     requirementValue = addIntegerField(pane, "Level: ", requirement.required_value, false, writable, listener);
                     break;
@@ -880,7 +904,15 @@ public class DialogueEditor extends JSONElementEditor {
                     } catch (IllegalArgumentException e) {
                     }
                     requirementObj = null;
-                    requirementSkill = addEnumValueBoxWithDescriptions(pane, "Skill ID:", Requirement.SkillID.values(), skillId, writable, Requirement.SkillID::getDescription, listener);
+                    requirementSkill = addEnumValueBoxWithDescriptions(
+                            pane,
+                            "Skill ID:",
+                            Requirement.SkillID.values(),
+                            skillId,
+                            writable,
+                            getEnumLabelGetter(Requirement.SkillID::getDescription),
+                            listener
+                    );
                     requirementObjId = null;//addTextField(pane, "Skill ID:", requirement.required_obj_id, writable, listener);
                     requirementValue = addIntegerField(pane, "Level up: ", requirement.required_value, false, writable, listener);
                     break;

--- a/src/com/gpl/rpg/atcontentstudio/ui/gamedataeditors/NPCEditor.java
+++ b/src/com/gpl/rpg/atcontentstudio/ui/gamedataeditors/NPCEditor.java
@@ -133,7 +133,15 @@ public class NPCEditor extends JSONElementEditor {
         experienceField = addIntegerField(pane, "Experience reward: ", npc.getMonsterExperience(), false, false, listener);
         dialogueBox = addDialogueBox(pane, npc.getProject(), "Initial phrase: ", npc.dialogue, npc.writable, listener);
         droplistBox = addDroplistBox(pane, npc.getProject(), "Droplist / Shop inventory: ", npc.droplist, npc.writable, listener);
-        monsterClassBox = addEnumValueBoxWithDescriptions(pane, "Monster class: ", NPC.MonsterClass.values(), npc.monster_class, npc.writable, NPC.MonsterClass::getDescription, listener);
+        monsterClassBox = addEnumValueBoxWithDescriptions(
+                pane,
+                "Monster class: ",
+                NPC.MonsterClass.values(),
+                npc.monster_class,
+                npc.writable,
+                NPC.MonsterClass::getDescription,
+                listener
+        );
         uniqueBox = addIntegerBasedCheckBox(pane, "Unique", npc.unique, npc.writable, listener);
         moveTypeBox = addEnumValueBox(pane, "Movement type: ", NPC.MovementType.values(), npc.movement_type, npc.writable, listener);
         combatTraitPane = new CollapsiblePanel("Combat traits: ");

--- a/src/com/gpl/rpg/atcontentstudio/ui/map/TMXMapEditor.java
+++ b/src/com/gpl/rpg/atcontentstudio/ui/map/TMXMapEditor.java
@@ -618,7 +618,7 @@ public class TMXMapEditor extends Editor implements TMXMap.MapChangedOnDiskListe
                             Requirement.SkillID.values(),
                             skillId,
                             writable,
-                            Requirement.SkillID::getDescription,
+                            getEnumLabelGetter(Requirement.SkillID::getDescription),
                             listener
                     );
                     requirementObjId = null;//addTextField(pane, "Skill ID:", requirement.required_obj_id, writable, listener);

--- a/src/com/gpl/rpg/atcontentstudio/ui/map/TMXMapEditor.java
+++ b/src/com/gpl/rpg/atcontentstudio/ui/map/TMXMapEditor.java
@@ -386,7 +386,15 @@ public class TMXMapEditor extends Editor implements TMXMap.MapChangedOnDiskListe
         } else if (selected instanceof KeyArea) {
             areaField = addTextField(pane, "Area ID: ", ((KeyArea) selected).name, ((TMXMap) target).writable, listener);
             dialogueBox = addDialogueBox(pane, ((TMXMap) target).getProject(), "Message when locked: ", ((KeyArea) selected).dialogue, ((TMXMap) target).writable, listener);
-            requirementTypeCombo = addEnumValueBoxWithDescriptions(pane, "Requirement type: ", Requirement.RequirementType.values(), ((KeyArea) selected).requirement.type, ((TMXMap) target).writable, Requirement.RequirementType::getDescription, listener);
+            requirementTypeCombo = addEnumValueBoxWithDescriptions(
+                    pane,
+                    "Requirement type: ",
+                    Requirement.RequirementType.values(),
+                    ((KeyArea) selected).requirement.type,
+                    ((TMXMap) target).writable,
+                    getEnumLabelGetter(Requirement.RequirementType::getDescription),
+                    listener
+            );
             requirementParamsPane = new JPanel();
             requirementParamsPane.setLayout(new JideBoxLayout(requirementParamsPane, JideBoxLayout.PAGE_AXIS, 6));
             pane.add(requirementParamsPane, JideBoxLayout.FIX);
@@ -450,7 +458,15 @@ public class TMXMapEditor extends Editor implements TMXMap.MapChangedOnDiskListe
             // Area ID field
             areaField = addTextField(pane, "Area ID: ", ((ReplaceArea) selected).name, ((TMXMap) target).writable, listener);
             // Requirement Type combobox
-            requirementTypeCombo = addEnumValueBoxWithDescriptions(pane, "Requirement type: ", Requirement.RequirementType.values(), ((ReplaceArea) selected).requirement.type, ((TMXMap) target).writable, Requirement.RequirementType::getDescription, listener);
+            requirementTypeCombo = addEnumValueBoxWithDescriptions(
+                    pane,
+                    "Requirement type: ",
+                    Requirement.RequirementType.values(),
+                    ((ReplaceArea) selected).requirement.type,
+                    ((TMXMap) target).writable,
+                    getEnumLabelGetter(Requirement.RequirementType::getDescription),
+                    listener
+            );
             // Set pane for variable requirement parameters (populated by updateRequirementParamsPane())
             requirementParamsPane = new JPanel();
             requirementParamsPane.setLayout(new JideBoxLayout(requirementParamsPane, JideBoxLayout.PAGE_AXIS, 6));
@@ -596,7 +612,15 @@ public class TMXMapEditor extends Editor implements TMXMap.MapChangedOnDiskListe
                         skillId = requirement.required_obj_id == null ? null : Requirement.SkillID.valueOf(requirement.required_obj_id);
                     } catch (IllegalArgumentException e) {
                     }
-                    requirementObj = addEnumValueBoxWithDescriptions(pane, "Skill ID:", Requirement.SkillID.values(), skillId, writable, Requirement.SkillID::getDescription, listener);
+                    requirementObj = addEnumValueBoxWithDescriptions(
+                            pane,
+                            "Skill ID:",
+                            Requirement.SkillID.values(),
+                            skillId,
+                            writable,
+                            Requirement.SkillID::getDescription,
+                            listener
+                    );
                     requirementObjId = null;//addTextField(pane, "Skill ID:", requirement.required_obj_id, writable, listener);
                     requirementValue = addIntegerField(pane, "Level: ", requirement.required_value, false, writable, listener);
                     break;
@@ -641,7 +665,15 @@ public class TMXMapEditor extends Editor implements TMXMap.MapChangedOnDiskListe
                         skillId = requirement.required_obj_id == null ? null : Requirement.SkillID.valueOf(requirement.required_obj_id);
                     } catch (IllegalArgumentException e) {
                     }
-                    requirementObj = addEnumValueBoxWithDescriptions(pane, "Skill ID:", Requirement.SkillID.values(), skillId, writable, Requirement.SkillID::getDescription, listener);
+                    requirementObj = addEnumValueBoxWithDescriptions(
+                            pane,
+                            "Skill ID:",
+                            Requirement.SkillID.values(),
+                            skillId,
+                            writable,
+                            getEnumLabelGetter(Requirement.SkillID::getDescription),
+                            listener
+                    );
                     requirementObjId = null;//addTextField(pane, "Skill ID:", requirement.required_obj_id, writable, listener);
                     requirementValue = addIntegerField(pane, "Level: ", requirement.required_value, false, writable, listener);
                     break;

--- a/src/com/gpl/rpg/atcontentstudio/ui/map/TMXMapEditor.java
+++ b/src/com/gpl/rpg/atcontentstudio/ui/map/TMXMapEditor.java
@@ -1852,7 +1852,6 @@ public class TMXMapEditor extends Editor implements TMXMap.MapChangedOnDiskListe
                 if (selectedLayer instanceof tiled.core.ObjectGroup) {
                     map.getGroup((tiled.core.ObjectGroup) selectedLayer).visible = layerVisibleBox.isSelected();
                 }
-                modified = false;
                 tmxViewer.revalidate();
                 tmxViewer.repaint();
             } else if (source == groupActiveForNewGame) {

--- a/src/com/gpl/rpg/atcontentstudio/ui/map/WorldMapEditor.java
+++ b/src/com/gpl/rpg/atcontentstudio/ui/map/WorldMapEditor.java
@@ -5,6 +5,7 @@ import com.gpl.rpg.atcontentstudio.Notification;
 import com.gpl.rpg.atcontentstudio.model.GameDataElement;
 import com.gpl.rpg.atcontentstudio.model.GameSource;
 import com.gpl.rpg.atcontentstudio.model.ProjectTreeNode;
+import com.gpl.rpg.atcontentstudio.model.Workspace;
 import com.gpl.rpg.atcontentstudio.model.maps.TMXMap;
 import com.gpl.rpg.atcontentstudio.model.maps.Worldmap;
 import com.gpl.rpg.atcontentstudio.model.maps.WorldmapSegment;
@@ -335,8 +336,29 @@ public class WorldMapEditor extends Editor implements FieldUpdateListener {
         };
 
         zoomSlider.addChangeListener(zoomChangeListener);
-        mapScroller.setWheelScrollingEnabled(false);
-        vPort.addMouseWheelListener(e -> {
+        mapScroller.setWheelScrollingEnabled(true);
+
+        // Remove any existing wheel listener on mapscroller
+        MouseWheelListener defaultWheelListener = null;
+        MouseWheelListener[] wheelListeners = mapScroller.getMouseWheelListeners();
+        if (wheelListeners.length > 0) {
+            defaultWheelListener = wheelListeners[0];
+            mapScroller.removeMouseWheelListener(defaultWheelListener);
+        }
+
+        // Set a new wheel listener on the mapscroller that checks Prefs option for control, and if
+        // not, pass the event on so the scroller moves up/down)
+        final MouseWheelListener finalDefaultWheelListener = defaultWheelListener;
+        mapScroller.addMouseWheelListener(e -> {
+            // Read the preference at event time so changes apply without reopening the editor.
+            boolean ctrlRequired = Workspace.activeWorkspace != null
+                    && Workspace.activeWorkspace.settings.zoomWorldMapOnlyWithCtrl.getCurrentValue();
+            if (ctrlRequired && !e.isControlDown()) {
+                if (finalDefaultWheelListener != null) {
+                    finalDefaultWheelListener.mouseWheelMoved(e);
+                }
+                return;
+            }
             int newZoom = zoomSlider.getValue() - (e.getWheelRotation() * WorldMapView.INC_ZOOM);
             newZoom = Math.clamp(newZoom, zoomSlider.getMinimum(), WorldMapView.MAX_ZOOM);
             if (newZoom != zoomSlider.getValue()) {

--- a/src/com/gpl/rpg/atcontentstudio/ui/map/WorldMapEditor.java
+++ b/src/com/gpl/rpg/atcontentstudio/ui/map/WorldMapEditor.java
@@ -5,7 +5,6 @@ import com.gpl.rpg.atcontentstudio.Notification;
 import com.gpl.rpg.atcontentstudio.model.GameDataElement;
 import com.gpl.rpg.atcontentstudio.model.GameSource;
 import com.gpl.rpg.atcontentstudio.model.ProjectTreeNode;
-import com.gpl.rpg.atcontentstudio.model.SaveEvent;
 import com.gpl.rpg.atcontentstudio.model.maps.TMXMap;
 import com.gpl.rpg.atcontentstudio.model.maps.Worldmap;
 import com.gpl.rpg.atcontentstudio.model.maps.WorldmapSegment;
@@ -45,6 +44,12 @@ public class WorldMapEditor extends Editor implements FieldUpdateListener {
     public String mapBeingAddedID = null;
     WorldMapView mapView = null;
     WorldmapSegment.NamedArea selectedLabel = null;
+
+    // Log-scale zoom endpoints expressed as actual zoom factors.
+    private static final float MIN_ZOOM_LEVEL = WorldMapView.MIN_ZOOM * WorldMapView.ZOOM_RATIO;
+    private static final float MAX_ZOOM_LEVEL = WorldMapView.MAX_ZOOM * WorldMapView.ZOOM_RATIO;
+    // Current lower zoom bound; updated after fitting the map to the viewport.
+    private float zoomFloor = MIN_ZOOM_LEVEL;
 
     MapSegmentMapsListModel msmListModel = null;
     ListSelectionModel msmListSelectionModel = null;
@@ -112,7 +117,7 @@ public class WorldMapEditor extends Editor implements FieldUpdateListener {
     private void applyZoom(JViewport viewport, JLabel zoomValueLabel, int newZoom, Point anchorPoint) {
         Point viewPosition = viewport.getViewPosition();
         float oldZoomLevel = mapView.zoomLevel;
-        mapView.zoomLevel = newZoom * WorldMapView.ZOOM_RATIO;
+        mapView.zoomLevel = sliderValueToZoom(newZoom);
         zoomValueLabel.setText(String.format(java.util.Locale.ROOT, "%.2fx", mapView.zoomLevel));
 
         // Use the anchor point to keep the same point in the map under the mouse cursor after zooming
@@ -143,6 +148,32 @@ public class WorldMapEditor extends Editor implements FieldUpdateListener {
         mapView.repaint();
     }
 
+    /**
+     * Converts a slider position to a logarithmically scaled zoom factor.
+     *
+     * @param sliderValue the current zoom slider value
+     * @return the zoom factor to apply to the world view
+     */
+    private float sliderValueToZoom(int sliderValue) {
+        float clamped = Math.clamp(sliderValue, WorldMapView.MIN_ZOOM, WorldMapView.MAX_ZOOM);
+        double t = (clamped - WorldMapView.MIN_ZOOM) / (double) (WorldMapView.MAX_ZOOM - WorldMapView.MIN_ZOOM);
+        return (float) (zoomFloor * Math.pow(MAX_ZOOM_LEVEL / zoomFloor, t));
+    }
+
+    /**
+     * Converts a zoom factor back into the matching slider position.
+     *
+     * @param zoomLevel the zoom factor currently applied
+     * @return the slider value that represents the zoom factor
+     */
+    private int zoomToSliderValue(float zoomLevel) {
+        float clamped = Math.clamp(zoomLevel, zoomFloor, MAX_ZOOM_LEVEL);
+        double t = Math.log(clamped / zoomFloor) / Math.log(MAX_ZOOM_LEVEL / zoomFloor);
+        return Math.clamp((int) Math.round(WorldMapView.MIN_ZOOM + t * (WorldMapView.MAX_ZOOM - WorldMapView.MIN_ZOOM)),
+                WorldMapView.MIN_ZOOM,
+                WorldMapView.MAX_ZOOM);
+    }
+
 
     @SuppressWarnings("unchecked")
     private JPanel buildSegmentTab(final WorldmapSegment worldmap) {
@@ -154,7 +185,7 @@ public class WorldMapEditor extends Editor implements FieldUpdateListener {
         JScrollPane mapScroller = new JScrollPane(mapView);
         final JViewport vPort = mapScroller.getViewport();
 
-        final JSlider zoomSlider = new JSlider(WorldMapView.MIN_ZOOM, WorldMapView.MAX_ZOOM, (int) (mapView.zoomLevel / WorldMapView.ZOOM_RATIO));
+        final JSlider zoomSlider = new JSlider(WorldMapView.MIN_ZOOM, WorldMapView.MAX_ZOOM, zoomToSliderValue(mapView.zoomLevel));
         zoomSlider.setSnapToTicks(true);
         zoomSlider.setMinorTickSpacing(WorldMapView.INC_ZOOM);
         zoomSlider.setPaintTicks(false);
@@ -340,12 +371,11 @@ public class WorldMapEditor extends Editor implements FieldUpdateListener {
                     }
 
                     float zoom = Math.min(extent.width / (float) mapView.sizeX, extent.height / (float) mapView.sizeY);
-                    zoom = Math.clamp(zoom, WorldMapView.MIN_ZOOM * WorldMapView.ZOOM_RATIO, WorldMapView.MAX_ZOOM * WorldMapView.ZOOM_RATIO);
+                    zoom = Math.clamp(zoom, MIN_ZOOM_LEVEL, MAX_ZOOM_LEVEL);
 
                     fitted = true;
-                    int fittedZoom = Math.clamp((int) Math.floor(zoom / WorldMapView.ZOOM_RATIO), WorldMapView.MIN_ZOOM, WorldMapView.MAX_ZOOM);
-                    zoomSlider.setMinimum(fittedZoom);
-                    zoomSlider.setValue(fittedZoom);
+                    zoomFloor = zoom;
+                    zoomSlider.setValue(zoomSlider.getMinimum());
                 }));
             }
         });

--- a/src/com/gpl/rpg/atcontentstudio/ui/map/WorldMapView.java
+++ b/src/com/gpl/rpg/atcontentstudio/ui/map/WorldMapView.java
@@ -42,6 +42,8 @@ public class WorldMapView extends JComponent implements Scrollable {
     int sizeX = 0, sizeY = 0;
     int offsetX = 0, offsetY = 0;
 
+    // Cached native-resolution renders for each TMX map, keyed by map id.
+    private final Map<String, CachedMapRender> renderedMapCache = new HashMap<String, CachedMapRender>();
 
     static final Color selectOutlineColor = new Color(255, 0, 0);
     static final Stroke selectOutlineStroke = new BasicStroke(4f);
@@ -148,7 +150,7 @@ public class WorldMapView extends JComponent implements Scrollable {
         return event.getPoint();
     }
 
-    private void paintOnGraphics(Graphics2D g2) {
+    private void paintOnGraphics(Graphics2D g2, Rectangle clip) {
         g2.setPaint(new Color(100, 100, 100));
         g2.fillRect(0, 0, sizeX, sizeY);
 
@@ -165,25 +167,28 @@ public class WorldMapView extends JComponent implements Scrollable {
         FontMetrics mifm = g2.getFontMetrics();
         int mapIdLabelHeight = mifm.getHeight();
 
-        for (String s : new HashSet<String>(mapLocations.keySet())) {
+        // Convert the screen clip to world coordinates so we only composite visible maps.
+        Rectangle visibleWorld = getVisibleWorldBounds(clip);
 
-            int x = mapLocations.get(s).x;
-            int y = mapLocations.get(s).y;
+        for (Map.Entry<String, Rectangle> entry : mapLocations.entrySet()) {
+            Rectangle bounds = entry.getValue();
+            if (visibleWorld != null && !visibleWorld.intersects(bounds)) continue;
 
-            TMXMap map = proj.getMap(s);
-            if (map == null) continue;
+            TMXMap map = proj.getMap(entry.getKey());
+            if (map == null || map.tmxMap == null) continue;
 
-            BufferedImage offscreen = renderMapOffscreen(map, g2);
-            g2.drawImage(offscreen, x, y, null);
-
+            BufferedImage offscreen = getRenderedMapImage(map, g2);
+            if (offscreen != null) {
+                g2.drawImage(offscreen, bounds.x, bounds.y, null);
+            }
         }
 
         if (highlightedListModel != null) {
-            outlineFromListModel(g2, highlightedListModel, null, highlightOutlineColor, highlightOutlineStroke, mapIdFont, mapIdLabelHeight);
+            outlineFromListModel(g2, highlightedListModel, null, highlightOutlineColor, highlightOutlineStroke, mapIdFont, mapIdLabelHeight, visibleWorld);
         }
 
         if (selectedListModel != null && selectedSelectionModel != null) {
-            outlineFromListModel(g2, selectedListModel, selectedSelectionModel, selectOutlineColor, selectOutlineStroke, mapIdFont, mapIdLabelHeight);
+            outlineFromListModel(g2, selectedListModel, selectedSelectionModel, selectOutlineColor, selectOutlineStroke, mapIdFont, mapIdLabelHeight, visibleWorld);
         }
 
 
@@ -236,6 +241,29 @@ public class WorldMapView extends JComponent implements Scrollable {
         }
 
         return offscreen;
+    }
+
+    /**
+     * Returns the cached render for a TMX map, rebuilding it when the map generation changes.
+     *
+     * @param map the map to render
+     * @param templateGraphics graphics context used to copy rendering hints
+     * @return a cached or freshly rendered image for the map
+     */
+    private BufferedImage getRenderedMapImage(TMXMap map, Graphics2D templateGraphics) {
+        CachedMapRender cached = renderedMapCache.get(map.id);
+        long generation = map.getRenderGeneration();
+        int mapWidth = Math.max(1, map.tmxMap.getWidth() * map.tmxMap.getTileWidth());
+        int mapHeight = Math.max(1, map.tmxMap.getHeight() * map.tmxMap.getTileHeight());
+
+        if (cached != null && cached.generation == generation && cached.image != null &&
+                cached.image.getWidth() == mapWidth && cached.image.getHeight() == mapHeight) {
+            return cached.image;
+        }
+
+        BufferedImage rendered = renderMapOffscreen(map, templateGraphics);
+        renderedMapCache.put(map.id, new CachedMapRender(generation, rendered));
+        return rendered;
     }
 
     /**
@@ -307,13 +335,16 @@ public class WorldMapView extends JComponent implements Scrollable {
         g2d.drawImage(object.getIcon(), object.x + 2, object.y + 2, null);
     }
 
-    private void outlineFromListModel(Graphics2D g2, ListModel<TMXMap> listModel, ListSelectionModel selectionModel, Color outlineColor, Stroke outlineStroke, Font mapIdFont, int mapIdLabelHeight) {
+    private void outlineFromListModel(Graphics2D g2, ListModel<TMXMap> listModel, ListSelectionModel selectionModel, Color outlineColor, Stroke outlineStroke, Font mapIdFont, int mapIdLabelHeight, Rectangle visibleWorld) {
         for (int i = 0; i < listModel.getSize(); i++) {
             //No selection model ? We want to highlight the whole list.
             if (selectionModel == null || selectionModel.isSelectedIndex(i)) {
                 TMXMap map = listModel.getElementAt(i);
-                int x = mapLocations.get(map.id).x;
-                int y = mapLocations.get(map.id).y;
+                Rectangle bounds = mapLocations.get(map.id);
+                if (bounds == null) continue;
+                if (visibleWorld != null && !visibleWorld.intersects(bounds)) continue;
+                int x = bounds.x;
+                int y = bounds.y;
 
                 g2.translate(x, y);
 
@@ -351,8 +382,7 @@ public class WorldMapView extends JComponent implements Scrollable {
         Graphics2D g2 = (Graphics2D) g.create();
         try {
             g2.scale(zoomLevel, zoomLevel);
-//			g2.drawImage(img, 0, 0, null);
-            paintOnGraphics(g2);
+            paintOnGraphics(g2, g.getClipBounds());
 
         } finally {
             g2.dispose();
@@ -460,6 +490,7 @@ public class WorldMapView extends JComponent implements Scrollable {
 
     public void updateFromModel() {
         mapLocations.clear();
+        renderedMapCache.clear();
         sizeX = sizeY = 0;
         offsetX = worldmap.segmentX * TILE_SIZE;
         offsetY = worldmap.segmentY * TILE_SIZE;
@@ -478,6 +509,23 @@ public class WorldMapView extends JComponent implements Scrollable {
 
             mapLocations.put(s, new Rectangle(x, y, w, h));
         }
+    }
+
+    /**
+     * Converts a screen-space clip rectangle into world coordinates.
+     *
+     * @param clip the component clip in screen coordinates
+     * @return the corresponding world-space bounds
+     */
+    private Rectangle getVisibleWorldBounds(Rectangle clip) {
+        if (clip == null) {
+            clip = new Rectangle(0, 0, Math.max(1, getWidth()), Math.max(1, getHeight()));
+        }
+        int x = (int) Math.floor(clip.x / zoomLevel);
+        int y = (int) Math.floor(clip.y / zoomLevel);
+        int w = (int) Math.ceil((clip.x + clip.width) / zoomLevel) - x;
+        int h = (int) Math.ceil((clip.y + clip.height) / zoomLevel) - y;
+        return new Rectangle(x, y, Math.max(1, w), Math.max(1, h));
     }
 
     public void pushToModel() {
@@ -504,6 +552,18 @@ public class WorldMapView extends JComponent implements Scrollable {
                 continue;
             }
             worldmap.getProject().getMap(id).addBacklink(worldmap);
+        }
+    }
+
+    private static final class CachedMapRender {
+        // Render version taken from TMXMap#getRenderGeneration().
+        private final long generation;
+        // Native-resolution map bitmap reused across paints.
+        private final BufferedImage image;
+
+        private CachedMapRender(long generation, BufferedImage image) {
+            this.generation = generation;
+            this.image = image;
         }
     }
 

--- a/src/com/gpl/rpg/atcontentstudio/ui/map/WorldMapView.java
+++ b/src/com/gpl/rpg/atcontentstudio/ui/map/WorldMapView.java
@@ -22,8 +22,8 @@ public class WorldMapView extends JComponent implements Scrollable {
     private static final long serialVersionUID = -4111374378777093799L;
 
     public static final int TILE_SIZE = 32;
-    public static final int MIN_ZOOM = 5;
-    public static final int MAX_ZOOM = 250;
+    public static final int MIN_ZOOM = 1;
+    public static final int MAX_ZOOM = 500;
     public static final int INC_ZOOM = 5;
     public static final float ZOOM_RATIO = 0.01f;
 


### PR DESCRIPTION
Merge changes for beta2.  
* Caching layer for Worldmap - VASTLY improved pan/zoom performance.
* Logarithmic zooming; should seem much more smooth.
* Preference setting to only zoom when Ctrl is held down (Image-editor model vs typical map viewer model).
* Added a `--show-console` argument for Windows.  Add it to the shortcut if you always want it to open.
* GDE comboboxes now list project elements first, followed by a section with all elements (each sorted).
* GDE comboboxes and lists color coded by source (green for Created, yellow for Altered).
* Preference setting to show enum names in comboboxes.  

## Copilot Summary
This pull request introduces several new user preferences and improvements to the application's behavior, especially for Windows users and editors working with maps and enum-based fields. The most significant changes are the addition of a `--show-console` command-line argument for Windows, new workspace settings for editor behavior, and UI enhancements to support these preferences. Additionally, there are improvements to map rendering cache invalidation and enum display options in editor comboboxes.

### Windows Console Support

* Added a `--show-console` command-line argument that allocates and attaches a console window on Windows. This helps users see standard output and error messages when running the GUI jar directly. The feature is documented in `README.md` and integrated into the application's startup logic. [[1]](diffhunk://#diff-9bee77cbe5cf1da2cdcff72f951577aacf0eca305b8e604f32f7dce7471558cbR53) [[2]](diffhunk://#diff-9bee77cbe5cf1da2cdcff72f951577aacf0eca305b8e604f32f7dce7471558cbR113-R122) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R59-R60) [[4]](diffhunk://#diff-9bee77cbe5cf1da2cdcff72f951577aacf0eca305b8e604f32f7dce7471558cbR574-R624) [[5]](diffhunk://#diff-9bee77cbe5cf1da2cdcff72f951577aacf0eca305b8e604f32f7dce7471558cbR648-R650)

### Workspace Settings Enhancements

* Added two new workspace settings: `zoomWorldMapOnlyWithCtrl` (controls whether world map zoom reacts only to Ctrl + mouse wheel) and `showEnumNamesInComboboxes` (controls whether enum names are shown in requirement, reward, and skill comboboxes). These are persisted in the workspace settings model. [[1]](diffhunk://#diff-d4dfa3b3bf00daf452fcbad8a1f867418cf27252b4a2bde3134b95d46936fd37R27-R29) [[2]](diffhunk://#diff-d4dfa3b3bf00daf452fcbad8a1f867418cf27252b4a2bde3134b95d46936fd37R38-R40) [[3]](diffhunk://#diff-d4dfa3b3bf00daf452fcbad8a1f867418cf27252b4a2bde3134b95d46936fd37R55-R59)

### UI Improvements

* Updated the `WorkspaceSettingsEditor` to include checkboxes for the new editor behavior settings, allowing users to toggle them in the GUI. The editor now loads and saves these preferences. [[1]](diffhunk://#diff-2ef33a1041c9f4a0bc1b9373cf036839f6d34c14ace1e5ab0a8f47847c2c65e3R20-R22) [[2]](diffhunk://#diff-2ef33a1041c9f4a0bc1b9373cf036839f6d34c14ace1e5ab0a8f47847c2c65e3R50) [[3]](diffhunk://#diff-2ef33a1041c9f4a0bc1b9373cf036839f6d34c14ace1e5ab0a8f47847c2c65e3R197-R216) [[4]](diffhunk://#diff-2ef33a1041c9f4a0bc1b9373cf036839f6d34c14ace1e5ab0a8f47847c2c65e3R242-R243)

### Map Rendering and Caching

* Introduced a `renderGeneration` field in `TMXMap` to track changes affecting the rendered map. This value increments on relevant changes (children, layers, reloads) and can be used for efficient cache invalidation by views. [[1]](diffhunk://#diff-ef9b943480ec4a4092594a3c16d242ce3c388025900a6f031428c3e46691c027R57-R58) [[2]](diffhunk://#diff-ef9b943480ec4a4092594a3c16d242ce3c388025900a6f031428c3e46691c027R182) [[3]](diffhunk://#diff-ef9b943480ec4a4092594a3c16d242ce3c388025900a6f031428c3e46691c027R345-R353) [[4]](diffhunk://#diff-ef9b943480ec4a4092594a3c16d242ce3c388025900a6f031428c3e46691c027R413) [[5]](diffhunk://#diff-ef9b943480ec4a4092594a3c16d242ce3c388025900a6f031428c3e46691c027R458-R466)

### Enum Combobox Display

* Updated various editors (e.g., `DialogueEditor`) to use a new label getter for enum-based comboboxes, which respects the `showEnumNamesInComboboxes` setting. This makes the display of enums in comboboxes customizable by the user. [[1]](diffhunk://#diff-f9b69b6f3172737b4d257f333a57364c927e2091be3b173e471d9ba1de46e346L226-R226) [[2]](diffhunk://#diff-f9b69b6f3172737b4d257f333a57364c927e2091be3b173e471d9ba1de46e346L425-R433) [[3]](diffhunk://#diff-f9b69b6f3172737b4d257f333a57364c927e2091be3b173e471d9ba1de46e346L471-R479) [[4]](diffhunk://#diff-f9b69b6f3172737b4d257f333a57364c927e2091be3b173e471d9ba1de46e346L775-R791) [[5]](diffhunk://#diff-f9b69b6f3172737b4d257f333a57364c927e2091be3b173e471d9ba1de46e346L837-R861)

Additionally, the description of the `questProgress` requirement type was clarified to "Quest max stage ever achieved" for better accuracy.